### PR TITLE
fix: update worker deployment env vars and entrypoint scripts

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -69,6 +69,7 @@
     "pino-pretty": "^13.1.1",
     "tmp-promise": "^3.0.3",
     "ioredis": "^5.7.0",
+    "tsx": "catalog:",
     "zod": "catalog:",
     "zod-openapi": "^4.2.4",
     "zod-prisma-types": "^3.2.4"
@@ -84,7 +85,6 @@
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "prisma": "^6.10.1",
-    "tsx": "^4.20.5",
     "typescript": "~5.9.2",
     "vitest": "catalog:",
     "vitest-mock-extended": "^3.1.0"

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -36,6 +36,7 @@
     "@biomejs/biome": "catalog:",
     "@playwright/test": "^1.55.0",
     "@sentry/vite-plugin": "^3.6.1",
+    "tsx": "catalog:",
     "@tanstack/react-router-devtools": "^1.131.50",
     "@tanstack/router-plugin": "^1.131.50",
     "@testing-library/jest-dom": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     react-dom:
       specifier: ^19.1.1
       version: 19.1.1
+    tsx:
+      specifier: ^4.20.5
+      version: 4.20.5
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
@@ -141,6 +144,9 @@ importers:
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.5
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -181,9 +187,6 @@ importers:
       prisma:
         specifier: ^6.10.1
         version: 6.14.0(magicast@0.3.5)(typescript@5.9.2)
-      tsx:
-        specifier: ^4.20.5
-        version: 4.20.5
       typescript:
         specifier: ~5.9.2
         version: 5.9.2
@@ -287,6 +290,9 @@ importers:
       playwright:
         specifier: ^1.55.0
         version: 1.55.0
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.5
       typescript:
         specifier: ~5.9.2
         version: 5.9.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - apps/*
 catalog:
   prisma: ^6.13.0
+  tsx: ^4.20.5
   zod: ^3.25.67
   react: ^19.1.1
   "@types/react": ^19.1.11

--- a/scripts/backend.entrypoint.sh
+++ b/scripts/backend.entrypoint.sh
@@ -8,4 +8,4 @@ echo "Init seed"
 pnpm --filter @sirena/backend db:seed
 
 cd /app/apps/backend
-exec node dist/src/index.js
+exec node_modules/.bin/tsx src/index.ts

--- a/scripts/worker.entrypoint.sh
+++ b/scripts/worker.entrypoint.sh
@@ -2,4 +2,4 @@
 set -e
 
 cd /app/apps/backend
-exec node dist/src/start-worker.js
+exec node_modules/.bin/tsx src/start-worker.ts


### PR DESCRIPTION
Switch worker and backend entrypoints to use compiled JS files. Add more environment variables and secret references to worker deployment. Make worker entrypoint script executable.