### PR TITLE
fix(us-399): refacto composant mon espace a11y

### DIFF
--- a/apps/frontend/src/components/layout/userMenu.css
+++ b/apps/frontend/src/components/layout/userMenu.css
@@ -1,20 +1,103 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+.user-menu__wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.user-menu__wrapper > button.fr-btn {
+  width: 100%;
+  justify-content: space-between;
+  margin: 0;
+}
+
+.user-menu {
+  position: static;
+  width: 100%;
+  margin: 0;
+
+  border-top: 1px solid var(--border-default-grey);
+  border-radius: var(--radius-1);
+  box-shadow: none;
+  text-align: left;
+}
+
+.user-menu__wrapper > button.fr-btn.user-menu-btn--open {
+  background-color: var(--artwork-decorative-blue-france) !important;
+  box-shadow: none !important;
+}
+
+.menu__trigger__icon {
+  margin-left: 0.25rem;
+  transition: transform 0.3s ease-in-out;
+}
+
+.menu__trigger__icon--is-open {
+  transform: rotate(180deg);
+}
+
+.user-menu__header {
+  color: var(--text-label-grey);
+  font-weight: 700;
+}
+
+.user-menu__header p {
+  margin: 0;
+}
+
+.user-menu__separator {
+  border-top: 1px solid var(--border-default-grey);
+}
+
+.user-menu a:hover {
+  color: var(--text-action-high-blue-france);
+}
+
 .user-menu__footer {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.25rem;
 }
 
-.user-menu__disconnect-btn {
+.user-menu__footer form {
   width: 100%;
-  display: flex;
-  justify-content: center;
 }
 
-.user-menu__item {
-  & .user-menu__item__icon {
-    margin-right: 0.5rem;
-    &::before {
-      --icon-size: 1rem;
-    }
+.user-menu__footer .user-menu__btn.fr-btn {
+  display: flex;
+  width: 100%;
+  max-width: 100%;
+  justify-content: center !important;
+  align-items: center;
+
+  border: 1px solid var(--border-default-grey);
+  box-shadow: none;
+  background-color: var(--background-default-grey);
+}
+
+@media (min-width: 62em) {
+  .user-menu-wrapper {
+    width: auto;
+  }
+
+  .user-menu-wrapper > button.fr-btn {
+    width: auto;
+    border-bottom: none;
+  }
+
+  .user-menu {
+    position: absolute;
+    top: calc(100% - 1px);
+    right: 4px;
+
+    min-width: 18rem;
+
+    border-top: none;
+    box-shadow: var(--shadow-overlap);
+    background-color: var(--background-default-grey);
   }
 }


### PR DESCRIPTION
Ce ticket traite du remplacement du composant Menu basé sur la librairie base-ui pour le composant "Mon espace".

Le composant précédent présentait plusieurs problèmes d’accessibilité :

- L’utilisation des flèches directionnelles n’était pas possible, alors que la norme WCAG recommande qu’un composant ayant role="menu" permette ce type de navigation.

- Le role="menu" n’était pas approprié, car il s’agit d’un menu de navigation utilitaire, et non d’un menu applicatif classique.

Après analyse et comparaison avec des composants similaires (DSFR, design.gouv.fr, site service-public.fr), j’ai implémenté un comportement plus conforme et accessible :

- Navigation par tabulation entre les items, conformément aux attentes pour un menu utilitaire.

- Fermeture du panneau lorsque le focus sort du menu.

- Fermeture du panneau lorsque l’utilisateur clique en dehors du menu.

- Retour du focus sur le bouton déclencheur uniquement à la fermeture du menu, pour éviter de déplacer le focus inutilement lors du chargement de la page.

Pour cohérence avec le DSFR :

- J’ai conservé le composant Button de @codegouvfr/react-dsfr pour profiter des styles et des comportements standards.

- Quelques !important ont été ajoutés pour override des styles DSFR ou hérités afin de s’assurer que le menu respecte le design voulu (alignement, largeur, couleurs, etc.).