### PR TITLE
release/v1.4.0

### DIFF
--- a/apps/backend/prisma/migrations/20260312161456_prepatch_merge_declarant_participant/migration.sql
+++ b/apps/backend/prisma/migrations/20260312161456_prepatch_merge_declarant_participant/migration.sql
@@ -1,0 +1,152 @@
+-- Pre-patch before migration 20260312161457_merge_declarant_participant_est_victime
+
+UPDATE "PersonneConcernee"
+SET "estVictime" = NULL
+WHERE id IN (
+  'e70e75c7-b22c-4460-b668-6eabe7d51572', -- RT228
+  'f9c9f5db-6d8e-4d14-a366-bce7182527da', -- RT171
+  '7fd96d1c-d50d-4b55-bdd3-d6557fbe893b', -- RT53
+  '7da7535d-899f-4755-a394-2a5f8469a460', -- RT121
+  '99f4048c-e6fe-4336-806f-d733a91f83b2', -- RT124
+  '17661cd8-f933-4fe1-abb4-e5eee6de4c93', -- RT152
+  'b10c0fe1-b949-46fa-b1df-fd3ededf4d63'  -- RT203
+);
+
+-- ============================================================
+-- STEP 2 : Concatenate diverging commentaires from #A into #B
+-- ============================================================
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '3c96b67d-ddc1-485c-ab04-56fd1b8018b7')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '3c96b67d-ddc1-485c-ab04-56fd1b8018b7')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '411f45be-70be-4edc-b640-bc99054d8c5f' -- #B RT11
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '3c96b67d-ddc1-485c-ab04-56fd1b8018b7' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '60a106ea-0a32-4c34-971a-d535bc0bbb60')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '60a106ea-0a32-4c34-971a-d535bc0bbb60')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '5bfe0c07-82a5-49d3-8502-6e284919dde8' -- #B RT22
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '60a106ea-0a32-4c34-971a-d535bc0bbb60' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '88f1b09f-420d-4df7-953c-1c2f66b9cdb9')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '88f1b09f-420d-4df7-953c-1c2f66b9cdb9')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '600e451d-22b1-4b31-9f5b-7b2f638ad5ce' -- #B RT36
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '88f1b09f-420d-4df7-953c-1c2f66b9cdb9' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'ce1bcbdf-e891-4439-a31c-e4b6b0b87b3d')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'ce1bcbdf-e891-4439-a31c-e4b6b0b87b3d')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '2a26b2b2-e2b4-4140-b401-fc6206d6888f' -- #B RT88
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = 'ce1bcbdf-e891-4439-a31c-e4b6b0b87b3d' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '71d218a9-7730-49b8-9c05-38cc951a3ae4')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '71d218a9-7730-49b8-9c05-38cc951a3ae4')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = 'c1264ecd-3583-45f7-b177-3bed2efc1e17' -- #B RT151
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '71d218a9-7730-49b8-9c05-38cc951a3ae4' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '1588fa75-8141-42d9-9b75-fa62b02955fa')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '1588fa75-8141-42d9-9b75-fa62b02955fa')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = 'b460f182-97bd-4361-a993-fea0dcf3ad1b' -- #B RT158
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '1588fa75-8141-42d9-9b75-fa62b02955fa' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '5b9a2c30-9a8c-4839-8fe4-80922caaa4b2')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '5b9a2c30-9a8c-4839-8fe4-80922caaa4b2')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '58e0c3ba-23ec-45fd-8901-1471a64c56ca' -- #B RT192
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '5b9a2c30-9a8c-4839-8fe4-80922caaa4b2' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'f2e595f6-3abe-458a-b80e-af8827aeb238')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'f2e595f6-3abe-458a-b80e-af8827aeb238')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '4a81d233-4e70-4839-959e-1d68a25585ed' -- #B RT196
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = 'f2e595f6-3abe-458a-b80e-af8827aeb238' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '4340db6a-5672-487c-ab24-5c05289d2eaa')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '4340db6a-5672-487c-ab24-5c05289d2eaa')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = 'ffa65278-3e17-4551-b2b3-221535729a66' -- #B RT197
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '4340db6a-5672-487c-ab24-5c05289d2eaa' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '20f8925b-3ebb-4350-9d64-a1a8bd49fd60')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '20f8925b-3ebb-4350-9d64-a1a8bd49fd60')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '50c05f7d-3e2a-4edf-8477-2a1755a0f175' -- #B RT211
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '20f8925b-3ebb-4350-9d64-a1a8bd49fd60' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '46bfd800-3520-49fb-934d-e440fac279b2')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '46bfd800-3520-49fb-934d-e440fac279b2')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = 'c77c78de-4962-4435-a44f-00c5984aa8a6' -- #B RT218
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '46bfd800-3520-49fb-934d-e440fac279b2' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'b8c95ecb-8243-4966-ac28-e16ab32eda2f')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'b8c95ecb-8243-4966-ac28-e16ab32eda2f')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '674d119c-582d-47f1-b051-a561dda05d1f' -- #B RT219
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = 'b8c95ecb-8243-4966-ac28-e16ab32eda2f' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '13d81b83-e794-4d22-8b84-b58fc2192ba2')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '13d81b83-e794-4d22-8b84-b58fc2192ba2')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = 'f1cc9b45-0b37-4922-9007-fd0819942866' -- #B RT221
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '13d81b83-e794-4d22-8b84-b58fc2192ba2' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'f44a401e-2f9d-4f8d-9b4f-b903e94baaa8')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'f44a401e-2f9d-4f8d-9b4f-b903e94baaa8')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '6ca9a333-824f-46d3-84b9-4b7b91532ff3' -- #B RT224
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = 'f44a401e-2f9d-4f8d-9b4f-b903e94baaa8' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '93ac9e98-83b2-449d-a3b8-f1b7ace5c4ae')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '93ac9e98-83b2-449d-a3b8-f1b7ace5c4ae')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '5d64dd74-ad83-4654-88e7-afec61497b99' -- #B RT226
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '93ac9e98-83b2-449d-a3b8-f1b7ace5c4ae' AND commentaire != '');

--- a/apps/backend/prisma/migrations/20260312161457_merge_declarant_participant_est_victime/migration.sql
+++ b/apps/backend/prisma/migrations/20260312161457_merge_declarant_participant_est_victime/migration.sql
@@ -1,0 +1,24 @@
+WITH to_merge AS (
+  -- Step 0 : Find pairs: (#A = declarant with estVictime=true, #B = separate participant for same requete)
+  SELECT
+    d.id              AS declarant_id,
+    p.id              AS participant_id,
+    d."declarantDeId" AS requete_id
+  FROM "PersonneConcernee" d
+  JOIN "PersonneConcernee" p ON p."participantDeId" = d."declarantDeId"
+  WHERE d."estVictime" = true
+    AND d."declarantDeId" IS NOT NULL
+    AND d."participantDeId" IS NULL
+    AND p.id != d.id
+),
+-- Step 1: Transfer declarantDeId to #B and mark estVictime = true
+set_participant AS (
+  UPDATE "PersonneConcernee" pc
+  SET "declarantDeId" = tm.requete_id,
+      "estVictime"    = true
+  FROM to_merge tm
+  WHERE pc.id = tm.participant_id
+)
+-- Step 2: Delete #A — cascades to its Identite and Adresse (onDelete: Cascade in schema)
+DELETE FROM "PersonneConcernee"
+WHERE id IN (SELECT declarant_id FROM to_merge);

--- a/apps/backend/prisma/migrations/20260331125713_prepatch_merge_declarant_participant_rt124_rt228/migration.sql
+++ b/apps/backend/prisma/migrations/20260331125713_prepatch_merge_declarant_participant_rt124_rt228/migration.sql
@@ -1,0 +1,17 @@
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = '99f4048c-e6fe-4336-806f-d733a91f83b2')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = '99f4048c-e6fe-4336-806f-d733a91f83b2')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '72686789-e4e0-41b1-a355-aa0da14dca5d' -- #B RT124
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = '99f4048c-e6fe-4336-806f-d733a91f83b2' AND commentaire != '');
+
+UPDATE "PersonneConcernee" SET commentaire =
+  CASE
+    WHEN commentaire = '' THEN (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'e70e75c7-b22c-4460-b668-6eabe7d51572')
+    ELSE (SELECT commentaire FROM "PersonneConcernee" WHERE id = 'e70e75c7-b22c-4460-b668-6eabe7d51572')
+         || E'\n---\n' || commentaire
+  END
+WHERE id = '643ca1ca-87c1-4e6f-ba82-6d2131782f7b' -- #B RT228
+  AND EXISTS (SELECT 1 FROM "PersonneConcernee" WHERE id = 'e70e75c7-b22c-4460-b668-6eabe7d51572' AND commentaire != '');

--- a/apps/backend/src/features/requetes/requetes.service.ts
+++ b/apps/backend/src/features/requetes/requetes.service.ts
@@ -129,6 +129,8 @@ export const createRequeteFromDematSocial = async ({
       },
     });
 
+    const isSamePerson = declarant.estVictime === true;
+
     const decl = await tx.personneConcernee.create({
       data: {
         identite: {
@@ -146,6 +148,7 @@ export const createRequeteFromDematSocial = async ({
         lienVictime: declarant.lienVictimeId ? { connect: { id: declarant.lienVictimeId } } : undefined,
         age: declarant.ageId ? { connect: { id: declarant.ageId } } : undefined,
         declarantDe: { connect: { id: requete.id } },
+        ...(isSamePerson ? { participantDe: { connect: { id: requete.id } } } : {}),
       },
     });
 
@@ -163,7 +166,7 @@ export const createRequeteFromDematSocial = async ({
       });
     }
 
-    if (participant) {
+    if (participant && !isSamePerson) {
       const part = await tx.personneConcernee.create({
         data: {
           identite: {

--- a/apps/backend/src/features/requetes/requetes.service.ts
+++ b/apps/backend/src/features/requetes/requetes.service.ts
@@ -147,6 +147,10 @@ export const createRequeteFromDematSocial = async ({
         veutGarderAnonymat: declarant.veutGarderAnonymat ?? null,
         lienVictime: declarant.lienVictimeId ? { connect: { id: declarant.lienVictimeId } } : undefined,
         age: declarant.ageId ? { connect: { id: declarant.ageId } } : undefined,
+        ...(isSamePerson && {
+          aAutrePersonnes: participant?.aAutrePersonnes ?? null,
+          autrePersonnes: participant?.autrePersonnes ?? '',
+        }),
         declarantDe: { connect: { id: requete.id } },
         ...(isSamePerson ? { participantDe: { connect: { id: requete.id } } } : {}),
       },

--- a/apps/backend/src/features/requetesEntite/requetesEntite.mapper.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.mapper.ts
@@ -35,7 +35,7 @@ export const mapDeclarantToPrismaCreate = (declarantData: DeclarantInput) => ({
   veutGarderAnonymat:
     declarantData.consentCommuniquerIdentite === undefined ? undefined : !declarantData.consentCommuniquerIdentite,
   isTuteur: declarantData.isTuteur ?? undefined,
-  estSignalementProfessionnel: declarantData.estSignalementProfessionnel || false,
+  estSignalementProfessionnel: declarantData.estSignalementProfessionnel ?? null,
   estVictime: declarantData.estPersonneConcernee || false,
   commentaire: declarantData.autresPrecisions || '',
   lienVictimeId:

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.test.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.test.ts
@@ -979,7 +979,16 @@ describe('requetesEntite.service', () => {
         data: { participantDeId: null },
       });
       expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
-        data: { participantDeId: 'req123' },
+        data: {
+          participantDeId: 'req123',
+          veutGarderAnonymat: false,
+          estHandicapee: null,
+          estVictimeInformee: null,
+          victimeInformeeCommentaire: '',
+          commentaire: '',
+          aAutrePersonnes: null,
+          autrePersonnes: '',
+        },
       });
     });
 
@@ -1003,6 +1012,13 @@ describe('requetesEntite.service', () => {
       expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
         data: {
           participantDeId: 'req123',
+          veutGarderAnonymat: false,
+          estHandicapee: null,
+          estVictimeInformee: null,
+          victimeInformeeCommentaire: '',
+          commentaire: '',
+          aAutrePersonnes: null,
+          autrePersonnes: '',
           identite: {
             create: {
               nom: 'Dupont',
@@ -1040,6 +1056,71 @@ describe('requetesEntite.service', () => {
       expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
         data: {
           participantDeId: 'req123',
+          veutGarderAnonymat: false,
+          estHandicapee: null,
+          estVictimeInformee: null,
+          victimeInformeeCommentaire: '',
+          commentaire: '',
+          aAutrePersonnes: null,
+          autrePersonnes: '',
+          identite: {
+            create: {
+              nom: 'Dupont',
+              prenom: 'Jean',
+              email: 'jean@example.com',
+              telephone: '0600000000',
+              civiliteId: 'M',
+            },
+          },
+          adresse: {
+            create: {
+              rue: '1 rue de la Paix',
+              codePostal: '75001',
+              ville: 'Paris',
+            },
+          },
+        },
+      });
+    });
+
+    it('uncheck: creates PC preserving all participant fields (ageId, veutGarderAnonymat, etc.)', async () => {
+      const declarantAsPC = {
+        ...baseDeclarant,
+        participantDeId: 'req123',
+        identite: mockIdentite,
+        adresse: mockAdresse,
+        ageId: 'age-adulte',
+        dateNaissance: new Date('1940-06-15'),
+        veutGarderAnonymat: true,
+        estHandicapee: false,
+        estVictimeInformee: true,
+        victimeInformeeCommentaire: 'commentaire informee',
+        commentaire: 'autres précisions',
+        aAutrePersonnes: true,
+        autrePersonnes: 'un enfant',
+      };
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst)
+        .mockResolvedValueOnce(declarantAsPC)
+        .mockResolvedValueOnce(declarantAsPC);
+      vi.mocked(prisma.personneConcernee.update).mockResolvedValueOnce({} as PersonneConcernee);
+      vi.mocked(prisma.personneConcernee.create).mockResolvedValueOnce({} as PersonneConcernee);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: false });
+
+      expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
+        data: {
+          participantDeId: 'req123',
+          ageId: 'age-adulte',
+          dateNaissance: new Date('1940-06-15'),
+          veutGarderAnonymat: true,
+          estHandicapee: false,
+          estVictimeInformee: true,
+          victimeInformeeCommentaire: 'commentaire informee',
+          commentaire: 'autres précisions',
+          aAutrePersonnes: true,
+          autrePersonnes: 'un enfant',
           identite: {
             create: {
               nom: 'Dupont',

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.test.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.test.ts
@@ -85,6 +85,12 @@ vi.mock('../../libs/prisma.js', () => ({
     uploadedFile: {
       findMany: vi.fn(),
     },
+    personneConcernee: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+      update: vi.fn(),
+    },
   },
 }));
 
@@ -705,6 +711,7 @@ describe('requetesEntite.service', () => {
         updatedAt: oldTimestamp,
         estSignalementProfessionnel: null,
         aAutrePersonnes: null,
+        isTuteur: null,
       };
 
       type RequeteWithDeclarant = Requete & {
@@ -779,6 +786,7 @@ describe('requetesEntite.service', () => {
         updatedAt: timestamp,
         estSignalementProfessionnel: null,
         aAutrePersonnes: null,
+        isTuteur: null,
       };
 
       type RequeteWithDeclarant = Requete & {
@@ -806,6 +814,7 @@ describe('requetesEntite.service', () => {
       } satisfies RequeteWithDeclarant as RequeteWithDeclarant);
 
       vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst).mockResolvedValueOnce(mockDeclarant);
 
       await updateRequeteDeclarant(
         'req123',
@@ -816,6 +825,250 @@ describe('requetesEntite.service', () => {
       );
 
       expect(prisma.requete.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateRequeteDeclarant - estPersonneConcernee', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    const baseDeclarant = {
+      id: 'declarant123',
+      estNonIdentifiee: null,
+      estHandicapee: null,
+      estIdentifie: true,
+      estSignalementProfessionnel: null,
+      estVictime: false,
+      estVictimeInformee: null,
+      victimeInformeeCommentaire: '',
+      veutGarderAnonymat: false,
+      commentaire: '',
+      autrePersonnes: '',
+      ageId: null,
+      dateNaissance: null,
+      lienVictimeId: null,
+      lienAutrePrecision: null,
+      declarantDeId: 'req123',
+      participantDeId: null,
+      aAutrePersonnes: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      identite: null,
+      adresse: null,
+    } as unknown as PersonneConcernee & { identite: Identite | null; adresse: null };
+
+    const mockIdentite = {
+      id: 'identite123',
+      nom: 'Dupont',
+      prenom: 'Jean',
+      email: 'jean@example.com',
+      telephone: '0600000000',
+      civiliteId: 'M',
+      commentaire: '',
+      personneConcerneeId: 'declarant123',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } satisfies Identite;
+
+    const mockAdresse = {
+      id: 'adresse123',
+      label: '',
+      numero: '',
+      rue: '1 rue de la Paix',
+      codePostal: '75001',
+      ville: 'Paris',
+      personneConcerneeId: 'declarant123',
+      lieuDeSurvenueId: null,
+    };
+
+    const mockRequeteWithoutDeclarant = {
+      id: 'req123',
+      dematSocialId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      createdById: null,
+      commentaire: '',
+      receptionDate: new Date(),
+      receptionTypeId: 'EMAIL',
+      provenanceId: null,
+      provenancePrecision: null,
+      thirdPartyAccountId: null,
+      declarant: null,
+    } as unknown as Requete;
+
+    it('check: connects participantDeId when no separate PC exists', async () => {
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst).mockResolvedValueOnce(baseDeclarant).mockResolvedValueOnce(null);
+      vi.mocked(prisma.personneConcernee.update).mockResolvedValueOnce({} as PersonneConcernee);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: true });
+
+      expect(prisma.personneConcernee.update).toHaveBeenCalledWith({
+        where: { id: 'declarant123' },
+        data: { participantDeId: 'req123' },
+      });
+      expect(prisma.personneConcernee.create).not.toHaveBeenCalled();
+      expect(prisma.personneConcernee.deleteMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: expect.any(String) } }),
+      );
+    });
+
+    it('check: does not reconnect if participantDeId is already set', async () => {
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst)
+        .mockResolvedValueOnce({ ...baseDeclarant, participantDeId: 'req123' })
+        .mockResolvedValueOnce(null);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: true });
+
+      expect(prisma.personneConcernee.update).not.toHaveBeenCalled();
+      expect(prisma.personneConcernee.create).not.toHaveBeenCalled();
+    });
+
+    it('check: when a separate PC exists, keeps PC data and deletes the declarant', async () => {
+      const existingParticipant = {
+        ...baseDeclarant,
+        id: 'participant456',
+        declarantDeId: null,
+        participantDeId: 'req123',
+        identite: mockIdentite,
+        adresse: mockAdresse,
+      } as unknown as PersonneConcernee;
+
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst)
+        .mockResolvedValueOnce(baseDeclarant)
+        .mockResolvedValueOnce(existingParticipant);
+      vi.mocked(prisma.personneConcernee.update).mockResolvedValue({} as PersonneConcernee);
+      vi.mocked(prisma.personneConcernee.deleteMany).mockResolvedValueOnce({ count: 1 });
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: true });
+
+      expect(prisma.personneConcernee.update).toHaveBeenCalledWith({
+        where: { id: 'declarant123' },
+        data: { declarantDeId: null },
+      });
+      expect(prisma.personneConcernee.update).toHaveBeenCalledWith({
+        where: { id: 'participant456' },
+        data: { declarantDeId: 'req123', estVictime: true },
+      });
+      expect(prisma.personneConcernee.deleteMany).toHaveBeenCalledWith({
+        where: { id: 'declarant123' },
+      });
+      expect(prisma.personneConcernee.create).not.toHaveBeenCalled();
+    });
+
+    it('uncheck: disconnects and creates an empty PC when declarant has no identite or adresse', async () => {
+      const declarantAsPC = { ...baseDeclarant, participantDeId: 'req123', identite: null, adresse: null };
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst)
+        .mockResolvedValueOnce(declarantAsPC)
+        .mockResolvedValueOnce(declarantAsPC);
+      vi.mocked(prisma.personneConcernee.update).mockResolvedValueOnce({} as PersonneConcernee);
+      vi.mocked(prisma.personneConcernee.create).mockResolvedValueOnce({} as PersonneConcernee);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: false });
+
+      expect(prisma.personneConcernee.update).toHaveBeenCalledWith({
+        where: { id: 'declarant123' },
+        data: { participantDeId: null },
+      });
+      expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
+        data: { participantDeId: 'req123' },
+      });
+    });
+
+    it('uncheck: creates PC with original identite even if declarant was edited before saving', async () => {
+      const declarantAsPC = { ...baseDeclarant, participantDeId: 'req123', identite: mockIdentite, adresse: null };
+      const declarantAfterUpdate = { ...baseDeclarant, participantDeId: 'req123', identite: null, adresse: null };
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst)
+        .mockResolvedValueOnce(declarantAsPC)
+        .mockResolvedValueOnce(declarantAfterUpdate);
+      vi.mocked(prisma.personneConcernee.update).mockResolvedValueOnce({} as PersonneConcernee);
+      vi.mocked(prisma.personneConcernee.create).mockResolvedValueOnce({} as PersonneConcernee);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: false });
+
+      expect(prisma.personneConcernee.update).toHaveBeenCalledWith({
+        where: { id: 'declarant123' },
+        data: { participantDeId: null },
+      });
+      expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
+        data: {
+          participantDeId: 'req123',
+          identite: {
+            create: {
+              nom: 'Dupont',
+              prenom: 'Jean',
+              email: 'jean@example.com',
+              telephone: '0600000000',
+              civiliteId: 'M',
+            },
+          },
+        },
+      });
+    });
+
+    it('uncheck: creates PC with both original identite and adresse', async () => {
+      const declarantAsPC = {
+        ...baseDeclarant,
+        participantDeId: 'req123',
+        identite: mockIdentite,
+        adresse: mockAdresse,
+      };
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst)
+        .mockResolvedValueOnce(declarantAsPC)
+        .mockResolvedValueOnce(declarantAsPC);
+      vi.mocked(prisma.personneConcernee.update).mockResolvedValueOnce({} as PersonneConcernee);
+      vi.mocked(prisma.personneConcernee.create).mockResolvedValueOnce({} as PersonneConcernee);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: false });
+
+      expect(prisma.personneConcernee.update).toHaveBeenCalledWith({
+        where: { id: 'declarant123' },
+        data: { participantDeId: null },
+      });
+      expect(prisma.personneConcernee.create).toHaveBeenCalledWith({
+        data: {
+          participantDeId: 'req123',
+          identite: {
+            create: {
+              nom: 'Dupont',
+              prenom: 'Jean',
+              email: 'jean@example.com',
+              telephone: '0600000000',
+              civiliteId: 'M',
+            },
+          },
+          adresse: {
+            create: {
+              rue: '1 rue de la Paix',
+              codePostal: '75001',
+              ville: 'Paris',
+            },
+          },
+        },
+      });
+    });
+
+    it('uncheck: does nothing if participantDeId is already null', async () => {
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequeteWithoutDeclarant);
+      vi.mocked(prisma.requete.update).mockResolvedValueOnce({} as Requete);
+      vi.mocked(prisma.personneConcernee.findFirst).mockResolvedValueOnce(null).mockResolvedValueOnce(baseDeclarant);
+
+      await updateRequeteDeclarant('req123', { estPersonneConcernee: false });
+
+      expect(prisma.personneConcernee.update).not.toHaveBeenCalled();
+      expect(prisma.personneConcernee.create).not.toHaveBeenCalled();
     });
   });
 
@@ -857,6 +1110,7 @@ describe('requetesEntite.service', () => {
         aAutrePersonnes: false,
         createdAt: timestamp,
         updatedAt: timestamp,
+        isTuteur: null,
       };
 
       type RequeteWithDeclarant = Requete & {

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -622,6 +622,15 @@ export const updateRequeteDeclarant = async (
       await prisma.personneConcernee.create({
         data: {
           participantDeId: requeteId,
+          ...(previousPcData?.ageId && { ageId: previousPcData.ageId }),
+          ...(previousPcData?.dateNaissance && { dateNaissance: previousPcData.dateNaissance }),
+          veutGarderAnonymat: previousPcData?.veutGarderAnonymat ?? null,
+          estHandicapee: previousPcData?.estHandicapee ?? null,
+          estVictimeInformee: previousPcData?.estVictimeInformee ?? null,
+          victimeInformeeCommentaire: previousPcData?.victimeInformeeCommentaire ?? '',
+          commentaire: previousPcData?.commentaire ?? '',
+          aAutrePersonnes: previousPcData?.aAutrePersonnes ?? null,
+          autrePersonnes: previousPcData?.autrePersonnes ?? '',
           ...(previousPcData?.identite && {
             identite: {
               create: {

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -532,7 +532,7 @@ export const updateRequete = async (requeteId: string, data: UpdateRequeteInput,
                   ? undefined
                   : !declarantData.consentCommuniquerIdentite,
               isTuteur: declarantData.isTuteur ?? undefined,
-              estSignalementProfessionnel: declarantData.estSignalementProfessionnel || false,
+              estSignalementProfessionnel: declarantData.estSignalementProfessionnel ?? null,
               estVictime: declarantData.estPersonneConcernee || false,
               commentaire: declarantData.autresPrecisions || '',
               lienVictimeId: lienVictimeValue,

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -386,6 +386,13 @@ export const createRequeteEntite = async (entiteId: string, data?: CreateRequete
         );
       }
 
+      if (data?.declarant?.estPersonneConcernee && requete.declarant) {
+        await prisma.personneConcernee.update({
+          where: { id: requete.declarant.id },
+          data: { participantDeId: requete.id },
+        });
+      }
+
       return requete;
     } catch (error: unknown) {
       if (error && typeof error === 'object' && 'code' in error) {
@@ -563,7 +570,84 @@ export const updateRequeteDeclarant = async (
   declarantData: DeclarantInput,
   controls?: UpdateRequeteControls,
 ) => {
-  return updateRequete(requeteId, { declarant: declarantData }, controls);
+  // capture the current PC data BEFORE the update so the new PC record keeps the original data
+  const previousPcData = !declarantData.estPersonneConcernee
+    ? await prisma.personneConcernee.findFirst({
+        where: { declarantDeId: requeteId, participantDeId: requeteId },
+        include: { identite: true, adresse: true },
+      })
+    : null;
+
+  const result = await updateRequete(requeteId, { declarant: declarantData }, controls);
+
+  const declarant = await prisma.personneConcernee.findFirst({
+    where: { declarantDeId: requeteId },
+  });
+
+  if (!declarant) return result;
+
+  if (declarantData.estPersonneConcernee) {
+    // Check if a separate PC record already exists
+    const existingParticipant = await prisma.personneConcernee.findFirst({
+      where: { participantDeId: requeteId, NOT: { id: declarant.id } },
+    });
+
+    if (existingParticipant) {
+      // Keep the PC's data: transfer declarantDeId to the existing PC record
+      await prisma.personneConcernee.update({
+        where: { id: declarant.id },
+        data: { declarantDeId: null },
+      });
+      await prisma.personneConcernee.update({
+        where: { id: existingParticipant.id },
+        data: { declarantDeId: requeteId, estVictime: true },
+      });
+      // Delete the old declarant record
+      await prisma.personneConcernee.deleteMany({
+        where: { id: declarant.id },
+      });
+    } else if (declarant.participantDeId !== requeteId) {
+      await prisma.personneConcernee.update({
+        where: { id: declarant.id },
+        data: { participantDeId: requeteId },
+      });
+    }
+  } else {
+    // separate PC record with the ORIGINAL data
+    if (declarant.participantDeId === requeteId) {
+      await prisma.personneConcernee.update({
+        where: { id: declarant.id },
+        data: { participantDeId: null },
+      });
+      await prisma.personneConcernee.create({
+        data: {
+          participantDeId: requeteId,
+          ...(previousPcData?.identite && {
+            identite: {
+              create: {
+                nom: previousPcData.identite.nom,
+                prenom: previousPcData.identite.prenom,
+                email: previousPcData.identite.email,
+                telephone: previousPcData.identite.telephone,
+                civiliteId: previousPcData.identite.civiliteId,
+              },
+            },
+          }),
+          ...(previousPcData?.adresse && {
+            adresse: {
+              create: {
+                rue: previousPcData.adresse.rue,
+                codePostal: previousPcData.adresse.codePostal,
+                ville: previousPcData.adresse.ville,
+              },
+            },
+          }),
+        },
+      });
+    }
+  }
+
+  return result;
 };
 
 export const updateRequeteParticipant = async (

--- a/apps/frontend/src/components/declarant/DeclarantForm.tsx
+++ b/apps/frontend/src/components/declarant/DeclarantForm.tsx
@@ -1,4 +1,6 @@
+import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import { Button } from '@codegouvfr/react-dsfr/Button';
+import { CallOut } from '@codegouvfr/react-dsfr/CallOut';
 import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox';
 import { Input } from '@codegouvfr/react-dsfr/Input';
 import { RadioButtons } from '@codegouvfr/react-dsfr/RadioButtons';
@@ -64,6 +66,10 @@ export function DeclarantForm({ mode, requestId, initialData, onSave }: Declaran
     const checked = e.target.checked;
     setFormData((prev: DeclarantData) => ({ ...prev, [field]: checked }));
   };
+
+  const [showPCWarning, setShowPCWarning] = useState(false);
+
+  const estPersonneConcernee = formData.estPersonneConcernee ?? false;
 
   const handleSave = async () => {
     setHasAttemptedSave(true);
@@ -144,233 +150,279 @@ export function DeclarantForm({ mode, requestId, initialData, onSave }: Declaran
             <legend>
               <h2 className="fr-h6 fr-mb-3w">Identité</h2>
             </legend>
-            <div className="fr-grid-row fr-grid-row--gutters">
-              <div className="fr-col-12 fr-col-md-3">
-                <Select
-                  label={declarantFieldMetadata.civilite.label}
-                  nativeSelectProps={{
-                    value: formData.civilite ?? '',
+            <Checkbox
+              className="fr-mb-2w"
+              options={[
+                {
+                  label: 'Le déclarant est la personne concernée par les faits',
+                  nativeInputProps: {
+                    checked: estPersonneConcernee,
                     onChange: (e) => {
-                      const value = e.target.value;
-                      setFormData((prev: DeclarantData) => ({ ...prev, civilite: value || undefined }));
+                      const checked = e.target.checked;
+                      setFormData((prev: DeclarantData) => ({ ...prev, estPersonneConcernee: checked }));
+                      if (checked) {
+                        const hasData = Object.entries(formData).some(
+                          ([key, value]) =>
+                            key !== 'estPersonneConcernee' && value !== undefined && value !== '' && value !== false,
+                        );
+                        setShowPCWarning(hasData);
+                      } else {
+                        setShowPCWarning(false);
+                      }
                     },
-                  }}
-                >
-                  <option value="">Sélectionner</option>
-                  {mappers.civiliteOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-              <div className="fr-col-12 fr-col-md-4">
-                <Input
-                  label={declarantFieldMetadata.nom.label}
-                  nativeInputProps={{
-                    value: formData.nom || '',
-                    onChange: handleInputChange('nom'),
-                  }}
+                  },
+                },
+              ]}
+            />
+            {estPersonneConcernee && showPCWarning && (
+              <div className="fr-mt-2w fr-mb-2w">
+                <Alert
+                  severity="warning"
+                  title="Avertissement"
+                  description='Si vous cochez cette case, les données renseignées dans la section "Déclarant" seront effacées. Seulement les données renseignées dans la section "Personne concernée" seront conservées.'
+                  small
                 />
               </div>
-              <div className="fr-col-12 fr-col-md-5">
-                <Input
-                  label={declarantFieldMetadata.prenom.label}
-                  nativeInputProps={{
-                    value: formData.prenom || '',
-                    onChange: handleInputChange('prenom'),
-                  }}
-                />
+            )}
+            {estPersonneConcernee && !showPCWarning && (
+              <div className="fr-mt-2w">
+                <CallOut>Enregistrez puis complétez la section "Personne concernée".</CallOut>
               </div>
+            )}
 
-              <div className="fr-col-12 fr-col-md-6">
-                <Select
-                  label={declarantFieldMetadata.lienAvecPersonneConcernee.label}
-                  nativeSelectProps={{
-                    value: formData.lienAvecPersonneConcernee ?? '',
-                    onChange: (e) => {
-                      const value = e.target.value;
-                      setFormData((prev: DeclarantData) => ({
-                        ...prev,
-                        lienAvecPersonneConcernee: value || undefined,
-                      }));
-                    },
-                  }}
-                >
-                  <option value="">Sélectionner une option</option>
-                  {mappers.lienAvecPersonneConcerneeOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-              {formData.lienAvecPersonneConcernee === 'AUTRE' && (
-                <div className="fr-col-12 fr-col-md-6">
+            {(!estPersonneConcernee || showPCWarning) && (
+              <div className="fr-grid-row fr-grid-row--gutters">
+                <div className="fr-col-12 fr-col-md-3">
+                  <Select
+                    label={declarantFieldMetadata.civilite.label}
+                    nativeSelectProps={{
+                      value: formData.civilite ?? '',
+                      onChange: (e) => {
+                        const value = e.target.value;
+                        setFormData((prev: DeclarantData) => ({ ...prev, civilite: value || undefined }));
+                      },
+                    }}
+                  >
+                    <option value="">Sélectionner</option>
+                    {mappers.civiliteOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                <div className="fr-col-12 fr-col-md-4">
                   <Input
-                    label={declarantFieldMetadata.lienAvecPersonneConcerneePrecision.label}
+                    label={declarantFieldMetadata.nom.label}
                     nativeInputProps={{
-                      value: formData.lienAvecPersonneConcerneePrecision || '',
-                      onChange: handleInputChange('lienAvecPersonneConcerneePrecision'),
-                      placeholder: 'Précisez votre lien avec la personne concernée',
+                      value: formData.nom || '',
+                      onChange: handleInputChange('nom'),
                     }}
                   />
                 </div>
-              )}
-              <div className="fr-col-12">
-                <Checkbox
+                <div className="fr-col-12 fr-col-md-5">
+                  <Input
+                    label={declarantFieldMetadata.prenom.label}
+                    nativeInputProps={{
+                      value: formData.prenom || '',
+                      onChange: handleInputChange('prenom'),
+                    }}
+                  />
+                </div>
+
+                <div className="fr-col-12 fr-col-md-6">
+                  <Select
+                    label={declarantFieldMetadata.lienAvecPersonneConcernee.label}
+                    nativeSelectProps={{
+                      value: formData.lienAvecPersonneConcernee ?? '',
+                      onChange: (e) => {
+                        const value = e.target.value;
+                        setFormData((prev: DeclarantData) => ({
+                          ...prev,
+                          lienAvecPersonneConcernee: value || undefined,
+                        }));
+                      },
+                    }}
+                  >
+                    <option value="">Sélectionner une option</option>
+                    {mappers.lienAvecPersonneConcerneeOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+                {formData.lienAvecPersonneConcernee === 'AUTRE' && (
+                  <div className="fr-col-12 fr-col-md-6">
+                    <Input
+                      label={declarantFieldMetadata.lienAvecPersonneConcerneePrecision.label}
+                      nativeInputProps={{
+                        value: formData.lienAvecPersonneConcerneePrecision || '',
+                        onChange: handleInputChange('lienAvecPersonneConcerneePrecision'),
+                        placeholder: 'Précisez votre lien avec la personne concernée',
+                      }}
+                    />
+                  </div>
+                )}
+                <div className="fr-col-12">
+                  <Checkbox
+                    options={[
+                      {
+                        label: declarantFieldMetadata.isTuteur.label,
+                        nativeInputProps: {
+                          checked: formData.isTuteur || false,
+                          onChange: handleCheckboxChange('isTuteur'),
+                        },
+                      },
+                    ]}
+                  />
+                </div>
+              </div>
+            )}
+          </fieldset>
+        </div>
+
+        {(!estPersonneConcernee || showPCWarning) && (
+          <>
+            <div
+              className="fr-p-4w fr-mb-4w"
+              style={{ border: '1px solid var(--border-default-grey)', borderRadius: '0.25rem' }}
+            >
+              <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+                <legend>
+                  <h2 className="fr-h6 fr-mb-3w">Informations de contact</h2>
+                </legend>
+                <div className="fr-grid-row fr-grid-row--gutters">
+                  <div className="fr-col-12 fr-col-md-6">
+                    <Input
+                      label={declarantFieldMetadata.adresseDomicile.label}
+                      nativeInputProps={{
+                        value: formData.adresseDomicile || '',
+                        onChange: handleInputChange('adresseDomicile'),
+                      }}
+                    />
+                  </div>
+                  <div className="fr-col-12 fr-col-md-2">
+                    <Input
+                      label={declarantFieldMetadata.codePostal.label}
+                      nativeInputProps={{
+                        value: formData.codePostal || '',
+                        onChange: handleInputChange('codePostal'),
+                        maxLength: 5,
+                      }}
+                    />
+                  </div>
+                  <div className="fr-col-12 fr-col-md-4">
+                    <Input
+                      label={declarantFieldMetadata.ville.label}
+                      nativeInputProps={{
+                        value: formData.ville || '',
+                        onChange: handleInputChange('ville'),
+                      }}
+                    />
+                  </div>
+                </div>
+
+                <div className="fr-grid-row fr-grid-row--gutters">
+                  <div className="fr-col-12 fr-col-md-6">
+                    <Input
+                      label={declarantFieldMetadata.numeroTelephone.label}
+                      hintText="Format attendu : 10 chiffres (français) ou +33XXXXXXXXXX (international)"
+                      state={phoneError ? 'error' : undefined}
+                      stateRelatedMessage={phoneError}
+                      nativeInputProps={{
+                        value: formData.numeroTelephone || '',
+                        onChange: handleInputChange('numeroTelephone'),
+                        type: 'tel',
+                        maxLength: 15,
+                      }}
+                    />
+                  </div>
+                  <div className="fr-col-12 fr-col-md-6">
+                    <Input
+                      label={declarantFieldMetadata.courrierElectronique.label}
+                      hintText="Exemple : prenom.nom@exemple.com"
+                      state={emailError ? 'error' : undefined}
+                      stateRelatedMessage={emailError}
+                      nativeInputProps={{
+                        value: formData.courrierElectronique || '',
+                        onChange: handleInputChange('courrierElectronique'),
+                        type: 'email',
+                      }}
+                    />
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+
+            <div
+              className="fr-p-4w fr-mb-4w"
+              style={{ border: '1px solid var(--border-default-grey)', borderRadius: '0.25rem' }}
+            >
+              <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+                <legend>
+                  <h2 className="fr-h6 fr-mb-3w">Informations complémentaires</h2>
+                </legend>
+                <RadioButtons
+                  legend={declarantFieldMetadata.consentCommuniquerIdentite.label}
+                  name="declarant-consent-identite"
+                  orientation="horizontal"
                   options={[
                     {
-                      label: declarantFieldMetadata.isTuteur.label,
+                      label: 'Oui',
                       nativeInputProps: {
-                        checked: formData.isTuteur || false,
-                        onChange: handleCheckboxChange('isTuteur'),
+                        value: 'true',
+                        checked: formData.consentCommuniquerIdentite === true,
+                        onChange: () => handleBooleanChange('consentCommuniquerIdentite', true),
+                      },
+                    },
+                    {
+                      label: 'Non',
+                      nativeInputProps: {
+                        value: 'false',
+                        checked: formData.consentCommuniquerIdentite === false,
+                        onChange: () => handleBooleanChange('consentCommuniquerIdentite', false),
                       },
                     },
                   ]}
                 />
-              </div>
+                <RadioButtons
+                  legend={declarantFieldMetadata.estSignalementProfessionnel.label}
+                  name="declarant-signalement-pro"
+                  orientation="horizontal"
+                  options={[
+                    {
+                      label: 'Oui',
+                      nativeInputProps: {
+                        value: 'true',
+                        checked: formData.estSignalementProfessionnel === true,
+                        onChange: () => handleBooleanChange('estSignalementProfessionnel', true),
+                      },
+                    },
+                    {
+                      label: 'Non',
+                      nativeInputProps: {
+                        value: 'false',
+                        checked: formData.estSignalementProfessionnel === false,
+                        onChange: () => handleBooleanChange('estSignalementProfessionnel', false),
+                      },
+                    },
+                  ]}
+                />
+
+                <Input
+                  label={declarantFieldMetadata.autresPrecisions.label}
+                  textArea
+                  nativeTextAreaProps={{
+                    value: formData.autresPrecisions || '',
+                    onChange: handleInputChange('autresPrecisions'),
+                    rows: 4,
+                  }}
+                />
+              </fieldset>
             </div>
-          </fieldset>
-        </div>
-
-        <div
-          className="fr-p-4w fr-mb-4w"
-          style={{ border: '1px solid var(--border-default-grey)', borderRadius: '0.25rem' }}
-        >
-          <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
-            <legend>
-              <h2 className="fr-h6 fr-mb-3w">Informations de contact</h2>
-            </legend>
-            <div className="fr-grid-row fr-grid-row--gutters">
-              <div className="fr-col-12 fr-col-md-6">
-                <Input
-                  label={declarantFieldMetadata.adresseDomicile.label}
-                  nativeInputProps={{
-                    value: formData.adresseDomicile || '',
-                    onChange: handleInputChange('adresseDomicile'),
-                  }}
-                />
-              </div>
-              <div className="fr-col-12 fr-col-md-2">
-                <Input
-                  label={declarantFieldMetadata.codePostal.label}
-                  nativeInputProps={{
-                    value: formData.codePostal || '',
-                    onChange: handleInputChange('codePostal'),
-                    maxLength: 5,
-                  }}
-                />
-              </div>
-              <div className="fr-col-12 fr-col-md-4">
-                <Input
-                  label={declarantFieldMetadata.ville.label}
-                  nativeInputProps={{
-                    value: formData.ville || '',
-                    onChange: handleInputChange('ville'),
-                  }}
-                />
-              </div>
-            </div>
-
-            <div className="fr-grid-row fr-grid-row--gutters">
-              <div className="fr-col-12 fr-col-md-6">
-                <Input
-                  label={declarantFieldMetadata.numeroTelephone.label}
-                  hintText="Format attendu : 10 chiffres (français) ou +33XXXXXXXXXX (international)"
-                  state={phoneError ? 'error' : undefined}
-                  stateRelatedMessage={phoneError}
-                  nativeInputProps={{
-                    value: formData.numeroTelephone || '',
-                    onChange: handleInputChange('numeroTelephone'),
-                    type: 'tel',
-                    maxLength: 15,
-                  }}
-                />
-              </div>
-              <div className="fr-col-12 fr-col-md-6">
-                <Input
-                  label={declarantFieldMetadata.courrierElectronique.label}
-                  hintText="Exemple : prenom.nom@exemple.com"
-                  state={emailError ? 'error' : undefined}
-                  stateRelatedMessage={emailError}
-                  nativeInputProps={{
-                    value: formData.courrierElectronique || '',
-                    onChange: handleInputChange('courrierElectronique'),
-                    type: 'email',
-                  }}
-                />
-              </div>
-            </div>
-          </fieldset>
-        </div>
-
-        <div
-          className="fr-p-4w fr-mb-4w"
-          style={{ border: '1px solid var(--border-default-grey)', borderRadius: '0.25rem' }}
-        >
-          <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
-            <legend>
-              <h2 className="fr-h6 fr-mb-3w">Informations complémentaires</h2>
-            </legend>
-            <RadioButtons
-              legend={declarantFieldMetadata.consentCommuniquerIdentite.label}
-              name="declarant-consent-identite"
-              orientation="horizontal"
-              options={[
-                {
-                  label: 'Oui',
-                  nativeInputProps: {
-                    value: 'true',
-                    checked: formData.consentCommuniquerIdentite === true,
-                    onChange: () => handleBooleanChange('consentCommuniquerIdentite', true),
-                  },
-                },
-                {
-                  label: 'Non',
-                  nativeInputProps: {
-                    value: 'false',
-                    checked: formData.consentCommuniquerIdentite === false,
-                    onChange: () => handleBooleanChange('consentCommuniquerIdentite', false),
-                  },
-                },
-              ]}
-            />
-            <RadioButtons
-              legend={declarantFieldMetadata.estSignalementProfessionnel.label}
-              name="declarant-signalement-pro"
-              orientation="horizontal"
-              options={[
-                {
-                  label: 'Oui',
-                  nativeInputProps: {
-                    value: 'true',
-                    checked: formData.estSignalementProfessionnel === true,
-                    onChange: () => handleBooleanChange('estSignalementProfessionnel', true),
-                  },
-                },
-                {
-                  label: 'Non',
-                  nativeInputProps: {
-                    value: 'false',
-                    checked: formData.estSignalementProfessionnel === false,
-                    onChange: () => handleBooleanChange('estSignalementProfessionnel', false),
-                  },
-                },
-              ]}
-            />
-
-            <Input
-              label={declarantFieldMetadata.autresPrecisions.label}
-              textArea
-              nativeTextAreaProps={{
-                value: formData.autresPrecisions || '',
-                onChange: handleInputChange('autresPrecisions'),
-                rows: 4,
-              }}
-            />
-          </fieldset>
-        </div>
+          </>
+        )}
 
         <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline-md">
           <Button priority="secondary" onClick={handleCancel}>

--- a/apps/frontend/src/components/requestId/sections/DeclarantSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/DeclarantSection.tsx
@@ -38,7 +38,10 @@ export const DeclarantSection = ({ requestId, id, declarant, editHref }: Declara
       : null,
   );
 
+  const isDeclarantPC = declarant?.estVictime === true;
+
   const isFulfilled =
+    isDeclarantPC ||
     !!fullName ||
     !!declarant?.lienVictime ||
     !!declarant?.lienAutrePrecision ||
@@ -51,6 +54,10 @@ export const DeclarantSection = ({ requestId, id, declarant, editHref }: Declara
     !!declarant?.estSignalementProfessionnel;
 
   const renderSummary = () => {
+    if (isDeclarantPC) {
+      return <p className="fr-mb-0">Le déclarant est la personne concernée par la requête.</p>;
+    }
+
     if (!fullName && !declarantIdentite?.email && !declarantIdentite?.telephone) return null;
 
     return (
@@ -75,6 +82,7 @@ export const DeclarantSection = ({ requestId, id, declarant, editHref }: Declara
   };
 
   const renderDetails = () => {
+    if (isDeclarantPC) return null;
     if (!isFulfilled) return null;
 
     const hasIdentitySection = !!fullName || !!declarant?.lienVictime || !!declarant?.lienAutrePrecision;

--- a/apps/frontend/src/lib/declarant.ts
+++ b/apps/frontend/src/lib/declarant.ts
@@ -27,7 +27,7 @@ function formatDeclarantFromServerImpl(declarant: DeclarantFromAPI) {
     estPersonneConcernee: declarant.estVictime || false,
     isTuteur: declarant.isTuteur || false,
     consentCommuniquerIdentite: declarant.veutGarderAnonymat === null ? undefined : !declarant.veutGarderAnonymat,
-    estSignalementProfessionnel: declarant.estSignalementProfessionnel || false,
+    estSignalementProfessionnel: declarant.estSignalementProfessionnel ?? undefined,
     autresPrecisions: declarant.commentaire || '',
   };
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,13 @@
       "ioredis": ">=5.10.0",
       "file-type@>=20.0.0 <=21.3.1": ">=21.3.2",
       "fast-xml-parser@>=4.0.0-beta.3 <=5.5.6": ">=5.5.7",
-      "effect@<3.20.0": ">=3.20.0"
+      "effect@<3.20.0": ">=3.20.0",
+      "micromatch>picomatch": "4.0.4",
+      "vite>picomatch": "4.0.4",
+      "vitest>picomatch": "4.0.4",
+      "picomatch@<2.3.2": ">=2.3.2",
+      "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
+      "brace-expansion@<5.0.5": ">=5.0.5"
     }
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -21,7 +21,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "types": ["@testing-library/jest-dom"]
   },
   "include": ["src"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,12 @@ overrides:
   file-type@>=20.0.0 <=21.3.1: '>=21.3.2'
   fast-xml-parser@>=4.0.0-beta.3 <=5.5.6: '>=5.5.7'
   effect@<3.20.0: '>=3.20.0'
+  micromatch>picomatch: 4.0.4
+  vite>picomatch: 4.0.4
+  vitest>picomatch: 4.0.4
+  picomatch@<2.3.2: '>=2.3.2'
+  yaml@>=2.0.0 <2.8.3: '>=2.8.3'
+  brace-expansion@<5.0.5: '>=5.0.5'
 
 importers:
 
@@ -197,7 +203,7 @@ importers:
         version: 24.10.13
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))
       prisma:
         specifier: ^6.19.2
         version: 6.19.2(typescript@5.9.3)
@@ -206,10 +212,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.1.0(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/frontend:
     dependencies:
@@ -267,7 +273,7 @@ importers:
         version: 1.163.3(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tanstack/router-core@1.163.3)(csstype@3.2.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.162.4
-        version: 1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -288,7 +294,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.7.0(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -309,10 +315,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/backend-utils:
     dependencies:
@@ -359,7 +365,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/ui:
     dependencies:
@@ -384,10 +390,10 @@ importers:
         version: 2.4.4
       '@storybook/addon-docs':
         specifier: ^10.2.12
-        version: 10.2.13(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.13(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react-vite':
         specifier: ^10.2.12
-        version: 10.2.13(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 10.2.13(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-router':
         specifier: ^1.162.4
         version: 1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -411,10 +417,10 @@ importers:
         version: 4.4.12(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -426,13 +432,13 @@ importers:
         version: 10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vite:
         specifier: ^7.1.11
-        version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest-browser-react:
         specifier: ^1.0.1
-        version: 1.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -2593,8 +2599,8 @@ packages:
   block-stream2@2.1.0:
     resolution: {integrity: sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3772,7 +3778,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -3952,12 +3957,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pino-abstract-transport@2.0.0:
@@ -4657,7 +4658,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4759,7 +4760,6 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -4839,8 +4839,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -5420,7 +5420,7 @@ snapshots:
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
-      yaml: 2.8.2
+      yaml: 2.8.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@fastify/websocket'
@@ -6036,11 +6036,11 @@ snapshots:
 
   '@ioredis/commands@1.5.1': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -6453,7 +6453,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.59.0
 
@@ -6758,10 +6758,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.2.13(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/addon-docs@10.2.13(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.2.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -6775,25 +6775,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       storybook: 10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.59.0
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -6808,11 +6808,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.2.13(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@storybook/react-vite@10.2.13(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-      '@storybook/builder-vite': 10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/builder-vite': 10.2.13(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react': 10.2.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -6822,7 +6822,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.13(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -6913,7 +6913,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/router-plugin@1.164.0(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -6930,7 +6930,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -7096,7 +7096,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -7104,11 +7104,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -7116,20 +7116,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -7137,7 +7137,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -7149,9 +7149,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7170,13 +7170,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7284,7 +7284,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   argparse@2.0.1: {}
 
@@ -7339,7 +7339,7 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7860,9 +7860,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -8440,7 +8440,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -8454,7 +8454,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -8683,9 +8683,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@2.0.0:
     dependencies:
@@ -8885,7 +8883,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   readdirp@4.1.2: {}
 
@@ -9229,8 +9227,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@2.0.0: {}
 
@@ -9331,7 +9329,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
@@ -9358,11 +9356,11 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.6
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -9371,28 +9369,28 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.8.2
+      yaml: 2.8.3
 
-  vitest-browser-react@1.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest-browser-react@1.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  vitest-mock-extended@3.1.0(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest-mock-extended@3.1.0(typescript@5.9.3)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -9403,13 +9401,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -9508,7 +9506,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Contenu de la MEP

### feat: déclarant <> personne concernée (PR #1106)
Fusion des rôles déclarant et personne concernée : possibilité de cocher `estPersonneConcernee` sur le déclarant pour qu'il soit également la personne concernée de la requête.

### fix: préservation des champs PC lors du décocher de estPersonneConcernee (PR #1126)
Lors du décocher de `estPersonneConcernee` sur le déclarant, les champs de la personne concernée (`veutGarderAnonymat`, `estHandicapee`, `commentaire`, `aAutrePersonnes`, etc.) sont désormais préservés.

### fix: préservation de aAutrePersonnes/autrePersonnes à l'import dematSocial (PR #1126)
Lors d'un import dematSocial où le déclarant est la même personne que la victime (`isSamePerson`), les champs `aAutrePersonnes` et `autrePersonnes` du participant sont maintenant correctement copiés.