### PR TITLE
fix: normalize SIRENA branding and add drag-and-drop

### DIFF
--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -150,7 +150,7 @@ describe('RequeteEtapes.service.ts', () => {
         nom: 'Envoyer un accusé de réception au déclarant',
         type: 'MANUAL',
         estPartagee: false,
-        statutId: 'A_FAIRE',
+        statutId: 'FAIT',
         createdAt: new Date(),
         updatedAt: new Date(),
         createdById: null,
@@ -188,7 +188,7 @@ describe('RequeteEtapes.service.ts', () => {
         data: {
           requeteId,
           entiteId,
-          statutId: 'A_FAIRE',
+          statutId: 'FAIT',
           nom: 'Envoyer un accusé de réception au déclarant',
         },
       });
@@ -230,7 +230,7 @@ describe('RequeteEtapes.service.ts', () => {
         nom: 'Envoyer un accusé de réception au déclarant',
         type: 'MANUAL',
         estPartagee: false,
-        statutId: 'A_FAIRE',
+        statutId: 'FAIT',
         createdAt: currentDate,
         updatedAt: currentDate,
         createdById: null,
@@ -293,7 +293,7 @@ describe('RequeteEtapes.service.ts', () => {
         nom: 'Envoyer un accusé de réception au déclarant',
         type: 'MANUAL',
         estPartagee: false,
-        statutId: 'A_FAIRE',
+        statutId: 'FAIT',
         createdAt: new Date(),
         updatedAt: new Date(),
         createdById: null,
@@ -332,7 +332,7 @@ describe('RequeteEtapes.service.ts', () => {
         data: {
           requeteId,
           entiteId,
-          statutId: 'A_FAIRE',
+          statutId: 'FAIT',
           nom: 'Envoyer un accusé de réception au déclarant',
         },
       });
@@ -370,7 +370,7 @@ describe('RequeteEtapes.service.ts', () => {
         nom: 'Envoyer un accusé de réception au déclarant',
         type: 'MANUAL',
         estPartagee: false,
-        statutId: 'A_FAIRE',
+        statutId: 'FAIT',
         createdAt: new Date(),
         updatedAt: new Date(),
         createdById: null,
@@ -386,7 +386,7 @@ describe('RequeteEtapes.service.ts', () => {
       expect(firstCall[0].data.nom).toMatch(/Création de la requête le \d{2}\/\d{2}\/\d{4}/);
     });
 
-    it('should create etapes with correct order (FAIT first, then A_FAIRE)', async () => {
+    it('should create etapes with correct order (both FAIT)', async () => {
       const requeteId = 'requeteId';
       const entiteId = 'entiteId';
       const receptionDate = new Date('2024-06-01T12:00:00Z');
@@ -418,7 +418,8 @@ describe('RequeteEtapes.service.ts', () => {
         nom: 'Envoyer un accusé de réception au déclarant',
         type: 'MANUAL',
         estPartagee: false,
-        statutId: 'A_FAIRE',
+        statutId: 'FAIT',
+        clotureReasonId: null,
         createdAt: new Date(),
         updatedAt: new Date(),
         createdById: null,
@@ -432,7 +433,7 @@ describe('RequeteEtapes.service.ts', () => {
 
       expect(result).not.toBeNull();
       expect(result?.etape1.statutId).toBe('FAIT');
-      expect(result?.etape2.statutId).toBe('A_FAIRE');
+      expect(result?.etape2.statutId).toBe('FAIT');
       expect(result?.etape1.nom).toContain('Création de la requête');
       expect(result?.etape2.nom).toBe('Envoyer un accusé de réception au déclarant');
     });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -90,7 +90,7 @@ export const createDefaultRequeteEtapes = async (
     data: {
       requeteId: requeteId,
       entiteId: entiteId,
-      statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE,
+      statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT,
       nom: ACKNOWLEDGMENT_STEP_NAME,
     },
   });

--- a/apps/backend/src/features/requetesEntite/requetesEntite.pdf.builder.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.pdf.builder.ts
@@ -100,7 +100,7 @@ export class RequetePdfBuilder {
         </rdf:Alt>
       </dc:title>
       <dc:language><rdf:Seq><rdf:li>fr-FR</rdf:li></rdf:Seq></dc:language>
-      <dc:creator><rdf:Seq><rdf:li>Sirena</rdf:li></rdf:Seq></dc:creator>
+      <dc:creator><rdf:Seq><rdf:li>SIRENA</rdf:li></rdf:Seq></dc:creator>
       <pdfuaid:part>1</pdfuaid:part>
     </rdf:Description>
   </rdf:RDF>

--- a/apps/backend/src/openAPI.thirdparty.ts
+++ b/apps/backend/src/openAPI.thirdparty.ts
@@ -15,9 +15,9 @@ const getServerUrl = () => {
 const getThirdPartyDocumentation = (): Documentation => ({
   openapi: '3.1.0',
   info: {
-    title: 'Sirena Third-Party API',
+    title: 'SIRENA Third-Party API',
     version: '1.0.0',
-    description: 'Sirena third-party integration API - requires API key authentication',
+    description: 'SIRENA third-party integration API - requires API key authentication',
   },
   servers: [
     {

--- a/apps/backend/src/openAPI.ts
+++ b/apps/backend/src/openAPI.ts
@@ -11,9 +11,9 @@ export function setupOpenAPI(app: Hono<AppBindings>, prefix = '/openapi') {
     openAPIRouteHandler(app, {
       documentation: {
         info: {
-          title: 'Sirena backend',
+          title: 'SIRENA backend',
           version: '1.0.0',
-          description: 'Sirena backend API',
+          description: 'SIRENA backend API',
         },
         servers: [
           {

--- a/apps/frontend/src/components/common/FileDropZone.module.css
+++ b/apps/frontend/src/components/common/FileDropZone.module.css
@@ -17,7 +17,8 @@
     border-color 0.3s ease;
 }
 
-.dropZone:hover {
+.dropZone:hover,
+.dropZoneDragging {
   border-color: var(--info-700-700);
 }
 

--- a/apps/frontend/src/components/common/FileDropZone.test.tsx
+++ b/apps/frontend/src/components/common/FileDropZone.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FileDropZone } from './FileDropZone';
+
+vi.mock('@codegouvfr/react-dsfr', () => ({
+  fr: {
+    cx: (...args: string[]) => args.join(' '),
+  },
+}));
+
+const defaultProps = {
+  selectedFiles: [] as File[],
+  fileErrors: {},
+  onFilesSelect: vi.fn(),
+};
+
+function renderDropZone(overrides = {}) {
+  return render(<FileDropZone {...defaultProps} {...overrides} />);
+}
+
+function createMockFile(name: string, type = 'application/pdf'): File {
+  return new File(['content'], name, { type });
+}
+
+function createDragEvent(files: File[]) {
+  const dataTransfer = {
+    files,
+    types: ['Files'],
+    items: files.map((f) => ({ kind: 'file', type: f.type, getAsFile: () => f })),
+  };
+  return { dataTransfer };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('FileDropZone', () => {
+  describe('rendering', () => {
+    it('should render the drop zone when canEdit is true', () => {
+      renderDropZone();
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('should not render the drop zone when canEdit is false', () => {
+      renderDropZone({ canEdit: false });
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('should display the empty message when no files are selected', () => {
+      renderDropZone({ emptyMessage: 'Aucun fichier' });
+      expect(screen.getByText('Aucun fichier')).toBeInTheDocument();
+    });
+
+    it('should hide the empty message when files are selected', () => {
+      renderDropZone({
+        selectedFiles: [createMockFile('test.pdf')],
+        emptyMessage: 'Aucun fichier',
+      });
+      expect(screen.queryByText('Aucun fichier')).not.toBeInTheDocument();
+    });
+
+    it('should display error message when provided', () => {
+      renderDropZone({ errorMessage: 'Erreur de téléchargement' });
+      expect(screen.getByText('Erreur de téléchargement')).toBeInTheDocument();
+    });
+
+    it('should display file validation errors', () => {
+      renderDropZone({
+        fileErrors: {
+          'test.exe': [{ type: 'type', message: 'Format non supporté' }],
+        },
+      });
+      expect(screen.getByText('test.exe')).toBeInTheDocument();
+      expect(screen.getByText('Format non supporté')).toBeInTheDocument();
+    });
+  });
+
+  describe('drag and drop', () => {
+    it('should call onFilesSelect when files are dropped', () => {
+      const onFilesSelect = vi.fn();
+      renderDropZone({ onFilesSelect });
+
+      const dropZone = screen.getByRole('button');
+      const file = createMockFile('test.pdf');
+
+      fireEvent.drop(dropZone, createDragEvent([file]));
+
+      expect(onFilesSelect).toHaveBeenCalledWith([file]);
+    });
+
+    it('should call onFilesSelect with multiple files', () => {
+      const onFilesSelect = vi.fn();
+      renderDropZone({ onFilesSelect });
+
+      const dropZone = screen.getByRole('button');
+      const files = [createMockFile('a.pdf'), createMockFile('b.pdf')];
+
+      fireEvent.drop(dropZone, createDragEvent(files));
+
+      expect(onFilesSelect).toHaveBeenCalledWith(files);
+    });
+
+    it('should not call onFilesSelect when dropping empty file list', () => {
+      const onFilesSelect = vi.fn();
+      renderDropZone({ onFilesSelect });
+
+      const dropZone = screen.getByRole('button');
+
+      fireEvent.drop(dropZone, createDragEvent([]));
+
+      expect(onFilesSelect).not.toHaveBeenCalled();
+    });
+
+    it('should not call onFilesSelect when isUploading is true', () => {
+      const onFilesSelect = vi.fn();
+      renderDropZone({ onFilesSelect, isUploading: true });
+
+      const dropZone = screen.getByRole('button');
+      const file = createMockFile('test.pdf');
+
+      fireEvent.drop(dropZone, createDragEvent([file]));
+
+      expect(onFilesSelect).not.toHaveBeenCalled();
+    });
+
+    it('should prevent default on dragOver', () => {
+      renderDropZone();
+      const dropZone = screen.getByRole('button');
+
+      const event = new Event('dragover', { bubbles: true, cancelable: true });
+      const prevented = !dropZone.dispatchEvent(event);
+
+      expect(prevented).toBe(true);
+    });
+  });
+
+  describe('file input', () => {
+    it('should call onFilesSelect when files are selected via input', () => {
+      const onFilesSelect = vi.fn();
+      renderDropZone({ onFilesSelect });
+
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const file = createMockFile('test.pdf');
+
+      fireEvent.change(input, { target: { files: [file] } });
+
+      expect(onFilesSelect).toHaveBeenCalledWith([file]);
+    });
+  });
+});

--- a/apps/frontend/src/components/common/FileDropZone.tsx
+++ b/apps/frontend/src/components/common/FileDropZone.tsx
@@ -1,5 +1,5 @@
 import { fr } from '@codegouvfr/react-dsfr';
-import { useId } from 'react';
+import { useId, useState } from 'react';
 
 import { ACCEPTED_FILE_TYPES, FILE_UPLOAD_HINT } from '@/utils/fileHelpers';
 import type { FileValidationError } from '@/utils/fileValidation';
@@ -56,6 +56,9 @@ export function FileDropZone({
     (maxSizeLabel || supportedFormatsLabel
       ? `Taille maximale : ${maxSizeLabel ?? '200 Mo'}. Formats supportés : ${supportedFormatsLabel ?? 'PDF, EML, Word, Excel, PowerPoint, OpenOffice, MSG, CSV, TXT, images (PNG, JPEG, HEIC, WEBP, TIFF)'}.`
       : FILE_UPLOAD_HINT);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounterRef = { current: 0 };
+
   const openFileDialog = () => {
     if (!canEdit || isUploading) {
       return;
@@ -67,17 +70,58 @@ export function FileDropZone({
     }
   };
 
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current++;
+    if (e.dataTransfer.types.includes('Files')) {
+      setIsDragging(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+    dragCounterRef.current = 0;
+
+    if (isUploading) return;
+
+    const { files } = e.dataTransfer;
+    if (files.length > 0) {
+      onFilesSelect(Array.from(files));
+    }
+  };
+
   return (
     <>
       {canEdit && (
         <div className={className}>
           <button
             type="button"
-            className={styles.dropZone}
+            className={[styles.dropZone, isDragging && styles.dropZoneDragging].filter(Boolean).join(' ')}
             disabled={isUploading}
             aria-describedby={hasGlobalError ? errorMessageId : undefined}
             aria-invalid={hasGlobalError || hasErrors}
             onClick={openFileDialog}
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
           >
             <p className={styles.dropZoneTitle}>{title}</p>
             <span className={[fr.cx('fr-btn', 'fr-btn--secondary'), styles.dropZoneButton].join(' ')}>

--- a/apps/frontend/src/components/common/FileDropZone.tsx
+++ b/apps/frontend/src/components/common/FileDropZone.tsx
@@ -1,5 +1,5 @@
 import { fr } from '@codegouvfr/react-dsfr';
-import { useId, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 
 import { ACCEPTED_FILE_TYPES, FILE_UPLOAD_HINT } from '@/utils/fileHelpers';
 import type { FileValidationError } from '@/utils/fileValidation';
@@ -57,7 +57,7 @@ export function FileDropZone({
       ? `Taille maximale : ${maxSizeLabel ?? '200 Mo'}. Formats supportés : ${supportedFormatsLabel ?? 'PDF, EML, Word, Excel, PowerPoint, OpenOffice, MSG, CSV, TXT, images (PNG, JPEG, HEIC, WEBP, TIFF)'}.`
       : FILE_UPLOAD_HINT);
   const [isDragging, setIsDragging] = useState(false);
-  const dragCounterRef = { current: 0 };
+  const dragCounterRef = useRef(0);
 
   const openFileDialog = () => {
     if (!canEdit || isUploading) {

--- a/apps/frontend/src/components/layout/footer.tsx
+++ b/apps/frontend/src/components/layout/footer.tsx
@@ -34,7 +34,7 @@ export function AppFooter() {
       ]}
       homeLinkProps={{
         href: '/',
-        title: 'Retour à l’accueil du site - Sirena - Ministère des Solidarités et de la Santé',
+        title: 'Retour à l’accueil du site - SIRENA - Ministère des Solidarités et de la Santé',
       }}
     />
   );

--- a/apps/frontend/src/components/layout/header.tsx
+++ b/apps/frontend/src/components/layout/header.tsx
@@ -53,10 +53,10 @@ export const HeaderMenu = (props: HeaderMenuProps) => {
         }
         homeLinkProps={{
           href: props.homeHref,
-          title: 'Accueil - Sirena',
+          title: 'Accueil - SIRENA',
         }}
         serviceTagline=""
-        serviceTitle="Sirena"
+        serviceTitle="SIRENA"
         id={id}
         quickAccessItems={quickAccessItems}
       />

--- a/apps/frontend/src/components/requestId/sections/OriginalRequestSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/OriginalRequestSection.tsx
@@ -311,13 +311,13 @@ export const OriginalRequestSection = ({ requestId, data, onEdit, updatedAt }: O
                 className={style.editButton}
                 iconId="fr-icon-pencil-line"
                 priority="tertiary no outline"
-                title={dateValue && typeValue ? 'Éditer' : 'Compléter'}
+                title={dateValue && typeValue ? 'Modifier' : 'Compléter'}
                 nativeButtonProps={{
-                  'aria-label': dateValue && typeValue ? 'Éditer' : 'Compléter',
+                  'aria-label': dateValue && typeValue ? 'Modifier' : 'Compléter',
                 }}
                 onClick={() => setIsEdit(true)}
               >
-                <span className="fr-sr-only">{dateValue && typeValue ? 'Éditer' : 'Compléter'}</span>
+                <span className="fr-sr-only">{dateValue && typeValue ? 'Modifier' : 'Compléter'}</span>
               </Button>
             )}
           </div>

--- a/apps/frontend/tests/ci/wait-for-deployment.ts
+++ b/apps/frontend/tests/ci/wait-for-deployment.ts
@@ -12,8 +12,9 @@ if (!EXPECTED_VERSION) {
   process.exit(1);
 }
 
-const MAX_ATTEMPTS = 60; // 5 minutes
-const DELAY_MS = 5000; // 5 seconds
+const MAX_ATTEMPTS = 120; // 10 minutes
+const INITIAL_DELAY_MS = 2000;
+const MAX_DELAY_MS = 10000;
 
 async function checkBackendVersion(): Promise<boolean> {
   try {
@@ -116,24 +117,33 @@ async function waitForDeployment() {
   console.log('🚀 Waiting for deployment to be ready...');
   console.log(`Expected version: ${EXPECTED_VERSION}`);
 
+  let backendReady = false;
+  let frontendReady = false;
+
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const delay = Math.min(INITIAL_DELAY_MS * Math.pow(1.5, Math.min(attempt - 1, 10)), MAX_DELAY_MS);
+
     console.log(`\n🔄 Attempt ${attempt}/${MAX_ATTEMPTS}`);
 
-    const isReady = await checkBothVersions();
-    if (isReady) {
+    if (!backendReady) {
+      backendReady = await checkBackendVersion();
+    }
+    if (!frontendReady) {
+      frontendReady = await checkFrontendVersion();
+    }
+
+    if (backendReady && frontendReady) {
       console.log('🎉 Deployment is ready! Starting e2e tests...');
       process.exit(0);
     }
 
     if (attempt < MAX_ATTEMPTS) {
-      console.log(`⏸️  Waiting ${DELAY_MS / 1000}s before next attempt...`);
-      await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+      console.log(`⏸️  Waiting ${(delay / 1000).toFixed(1)}s before next attempt...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 
-  console.error(
-    `❌ Deployment not ready after ${MAX_ATTEMPTS} attempts (${(MAX_ATTEMPTS * DELAY_MS) / 60000} minutes)`,
-  );
+  console.error(`❌ Deployment not ready after ${MAX_ATTEMPTS} attempts (~10 minutes)`);
   console.error('This might indicate a deployment issue or the version endpoint is not working correctly.');
   process.exit(1);
 }

--- a/helm_charts/charts/backend/values.yaml
+++ b/helm_charts/charts/backend/values.yaml
@@ -93,7 +93,7 @@ SDPSN-devops-charts:
     ANNUAIRE_SANTE_API_URL: "https://gateway.api.esante.gouv.fr/fhir/v2"
     TIPIMAIL_API_URL: "https://api.tipimail.com/v1"
     TIPIMAIL_FROM_ADDRESS: "ne-pas-repondre@sirena-sante.social.gouv.fr"
-    TIPIMAIL_FROM_PERSONAL_NAME: "Sirena"
+    TIPIMAIL_FROM_PERSONAL_NAME: "SIRENA"
     TIPIMAIL_DISABLE_SENDING: "true"
     MONITORING_PORT: "9090"
     CLAMAV_PORT: "3310"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
       "prisma"
     ],
     "overrides": {
-      "lodash": ">=4.18.0"
+      "lodash": ">=4.18.0",
+      "@hono/node-server@<1.19.13": ">=1.19.13"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ catalogs:
 
 overrides:
   lodash: '>=4.18.0'
+  '@hono/node-server@<1.19.13': '>=1.19.13'
 
 importers:
 
@@ -1278,12 +1279,6 @@ packages:
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
@@ -6534,10 +6529,6 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@hono/node-server@1.19.11(hono@4.12.12)':
-    dependencies:
-      hono: 4.12.12
-
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -7102,7 +7093,7 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.12)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2


### PR DESCRIPTION
- Add drag state, handlers and unit tests for FileDropZone
- Add CSS class for dragging visual state
- Replace "Sirena" with "SIRENA" across backend and frontend
- Improve CI wait-for-deployment with backoff and separate checks
- Change UI label "Éditer" to "Modifier" in OriginalRequestSection