### PR TITLE
fix: use pnpm action-setup in CI

### DIFF
--- a/.github/workflows/auto-deploy.yaml
+++ b/.github/workflows/auto-deploy.yaml
@@ -69,8 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
 
-      - name: Enable corepack
-        run: corepack enable pnpm
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -92,13 +91,10 @@ jobs:
           cd apps/frontend
           npx playwright install --with-deps chromium
 
-      - name: Install tsx
-        run: pnpm add -g tsx
-
       - name: Wait for deployment
         run: |
           cd apps/frontend
-          npx tsx tests/ci/wait-for-deployment.ts
+          pnpm dlx tsx tests/ci/wait-for-deployment.ts
         env:
           EXPECTED_VERSION: ${{ needs.build-docker.outputs.version }}
           BACKEND_URL: ${{ env.BASE_URL }}/api

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -14,8 +14,7 @@ jobs:
       PG_URL: postgresql://placeholder:placeholder@localhost:5432/placeholder?schema=public
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
-      - name: Enable corepack
-        run: corepack enable pnpm
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
       - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
Remove global tsx install and invoke tsx via pnpm dlx in auto-deploy Updated .github/workflows/auto-deploy.yaml and lint-and-test.yaml