### PR TITLE
feat: render last names as JSX nodes

### DIFF
--- a/apps/frontend/src/components/common/tables/requetesEntites.cells.tsx
+++ b/apps/frontend/src/components/common/tables/requetesEntites.cells.tsx
@@ -68,6 +68,14 @@ const renderInlineList = (items: string[]): ReactNode => (
   </ul>
 );
 
+const renderInlineNodeList = (items: Array<{ key: string; node: ReactNode }>): ReactNode => (
+  <ul className={styles.inlineList}>
+    {items.map((item) => (
+      <li key={item.key}>{item.node}</li>
+    ))}
+  </ul>
+);
+
 const renderList = (items: string[]): ReactNode => (
   <ul className={styles.list}>
     {items.map((item) => (
@@ -179,36 +187,60 @@ const getMisEnCauseTypeInfo = (misEnCause: MisEnCause) => {
   return { typeId, typeLabel, precisionLabel: misEnCause?.misEnCauseTypePrecision?.label };
 };
 
+const buildIdentity = (misEnCause: MisEnCause): { key: string; node: ReactNode } | null => {
+  const civilite = misEnCause?.civilite ?? '';
+  const prenom = misEnCause?.prenom ?? '';
+  const nom = misEnCause?.nom ?? '';
+  const commentaire = misEnCause?.commentaire?.trim() ?? '';
+
+  if (civilite || prenom || nom) {
+    const key = [civilite, prenom, nom].filter(Boolean).join(' ').trim();
+    return {
+      key,
+      node: (
+        <>
+          {[civilite, prenom].filter(Boolean).join(' ')}
+          {(civilite || prenom) && nom ? ' ' : ''}
+          {nom && <span className="lastname">{nom}</span>}
+        </>
+      ),
+    };
+  }
+
+  if (commentaire) return { key: commentaire, node: commentaire };
+  return null;
+};
+
+const toStringItem = (value: string): { key: string; node: ReactNode } => ({ key: value, node: value });
+
 const getMisEnCauseDisplayValue = (
   typeId: MisEnCauseType,
   typeLabel: string,
   precisionLabel: string | undefined,
   misEnCause: MisEnCause,
   lieuDeSurvenue: LieuDeSurvenue,
-): string => {
-  const identity =
-    [misEnCause?.civilite, misEnCause?.prenom, misEnCause?.nom].filter(Boolean).join(' ').trim() ||
-    misEnCause?.commentaire?.trim();
+): { key: string; node: ReactNode } => {
+  const identity = buildIdentity(misEnCause);
 
   switch (typeId) {
     case MIS_EN_CAUSE_TYPE.PROFESSIONNEL_SANTE:
-      return identity || precisionLabel || typeLabel;
+      return identity || toStringItem(precisionLabel || typeLabel);
 
     case MIS_EN_CAUSE_TYPE.ETABLISSEMENT: {
       if (misEnCause?.nomService) {
-        return misEnCause.nomService;
+        return toStringItem(misEnCause.nomService);
       }
       const isEtablissementLieu = ETABLISSEMENT_LIEU_TYPES.includes(lieuDeSurvenue?.lieuTypeId || '');
       const establishmentName = isEtablissementLieu ? lieuDeSurvenue?.adresse?.label : undefined;
-      return establishmentName || precisionLabel || typeLabel;
+      return toStringItem(establishmentName || precisionLabel || typeLabel);
     }
 
     default:
-      return precisionLabel || typeLabel;
+      return toStringItem(precisionLabel || typeLabel);
   }
 };
 
-const extractMisEnCauseFromSituation = (situation: Situation): string | null => {
+const extractMisEnCauseFromSituation = (situation: Situation): { key: string; node: ReactNode } | null => {
   const typeInfo = getMisEnCauseTypeInfo(situation.misEnCause);
   if (!typeInfo) return null;
 
@@ -224,11 +256,11 @@ const extractMisEnCauseFromSituation = (situation: Situation): string | null => 
 export function renderMisEnCauseCell(row: RequeteEntiteRow): ReactNode {
   const items = (row.requete.situations ?? [])
     .map(extractMisEnCauseFromSituation)
-    .filter((v): v is string => v !== null);
+    .filter((v): v is { key: string; node: ReactNode } => v !== null);
 
-  const uniqueItems = [...new Set(items)];
+  const uniqueItems = uniqueBy(items, (item) => item.key);
 
-  return uniqueItems.length === 0 ? UNKNOWN_VALUE : renderInlineList(uniqueItems);
+  return uniqueItems.length === 0 ? UNKNOWN_VALUE : renderInlineNodeList(uniqueItems);
 }
 
 export function renderAffectationCell(row: RequeteEntiteRow, userTopEntiteId: string): ReactNode {

--- a/apps/frontend/src/components/common/tables/requetesEntites.tsx
+++ b/apps/frontend/src/components/common/tables/requetesEntites.tsx
@@ -275,7 +275,7 @@ export function RequetesEntite() {
       if (participant?.identite) {
         return (
           <span className="one-line">
-            {participant.identite.prenom} {participant.identite.nom}
+            {participant.identite.prenom} <span className="lastname">{participant.identite.nom}</span>
           </span>
         );
       }

--- a/apps/frontend/src/components/layout/userMenu.tsx
+++ b/apps/frontend/src/components/layout/userMenu.tsx
@@ -14,10 +14,18 @@ export const UserMenu = () => {
   const { data } = useProfile();
   const matches = useMatches();
 
-  const displayName = useMemo(
-    () => [data?.nom, data?.prenom].filter(Boolean).join(' ').trim() || '',
-    [data?.nom, data?.prenom],
-  );
+  const displayName = useMemo(() => {
+    const nom = data?.nom?.trim() ?? '';
+    const prenom = data?.prenom?.trim() ?? '';
+    if (!nom && !prenom) return null;
+    return (
+      <>
+        {nom && <span className="lastname">{nom}</span>}
+        {nom && prenom ? ' ' : ''}
+        {prenom}
+      </>
+    );
+  }, [data?.nom, data?.prenom]);
   const email = useMemo(() => data?.email ?? '', [data]);
   const role = useMemo(() => (data?.role?.id ?? '') as Role | '', [data]);
   const affectationChain = useMemo(
@@ -129,7 +137,7 @@ export const UserMenu = () => {
       {isOpen && (
         <div id={menuId} ref={popupRef} className="user-menu fr-card">
           <div className="user-menu__header fr-p-2w">
-            <p className="fr-text--bold">{displayName || 'Mon espace'}</p>
+            <p className="fr-text--bold">{displayName ?? 'Mon espace'}</p>
             {email && <p className="fr-hint-text">{email}</p>}
             {affectationChain.length > 0 && (
               <div className={clsx('fr-hint-text', 'fr-mt-1v')} data-testid="user-menu-affectation">

--- a/apps/frontend/src/components/requestForm/RequestForm.tsx
+++ b/apps/frontend/src/components/requestForm/RequestForm.tsx
@@ -45,7 +45,7 @@ export function RequestForm({ requestId }: RequestFormProps) {
       ? {
           civilite: declarantIdentite.civiliteId ? { label: declarantIdentite.civiliteId } : undefined,
           prenom: declarantIdentite.prenom,
-          nom: declarantIdentite.nom?.toUpperCase() || '',
+          nom: declarantIdentite.nom || '',
         }
       : null,
   );

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -38,13 +38,23 @@ type StepProps = StepType & {
 const formatDate = (dateStr: string) =>
   new Date(dateStr).toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' });
 
+const formatAgent = (agent: { prenom: string; nom: string }): React.ReactNode => (
+  <>
+    {capitalizeFirst(agent.prenom)} <span className="lastname">{capitalizeFirst(agent.nom)}</span>
+  </>
+);
+
 const formatStepCreationInfo = (
   createdBy: { prenom: string; nom: string } | null | undefined,
   createdAt: string,
-): string => {
+): React.ReactNode => {
   const date = formatDate(createdAt);
   if (createdBy) {
-    return `Ajouté par ${capitalizeFirst(createdBy.prenom)} ${capitalizeFirst(createdBy.nom)} le ${date}`;
+    return (
+      <>
+        Ajouté par {formatAgent(createdBy)} le {date}
+      </>
+    );
   }
   return `Ajouté automatiquement le ${date}`;
 };
@@ -68,22 +78,31 @@ const getStepSubtitle = (
   createdBy: { prenom: string; nom: string } | null | undefined,
   requete: RequeteRef,
   clotureNoteAuthor?: { prenom: string; nom: string } | null,
-): string => {
+): React.ReactNode => {
   const date = formatDate(createdAt);
 
   if (statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) {
     const agent = createdBy ?? clotureNoteAuthor;
-    const agentPart = agent ? ` par ${capitalizeFirst(agent.prenom)} ${capitalizeFirst(agent.nom)}` : '';
-    return `Requête clôturée le ${date}${agentPart}`;
+    if (agent) {
+      return (
+        <>
+          Requête clôturée le {date} par {formatAgent(agent)}
+        </>
+      );
+    }
+    return `Requête clôturée le ${date}`;
   }
 
   if (type === REQUETE_ETAPE_TYPES.CREATION) {
     const isManual = requete?.dematSocialId == null && requete?.createdBy != null;
-    const creatorPart =
-      isManual && requete?.createdBy
-        ? ` par ${capitalizeFirst(requete.createdBy.prenom)} ${capitalizeFirst(requete.createdBy.nom)}`
-        : '';
-    return `Requête créée le ${date}${creatorPart}`;
+    if (isManual && requete?.createdBy) {
+      return (
+        <>
+          Requête créée le {date} par {formatAgent(requete.createdBy)}
+        </>
+      );
+    }
+    return `Requête créée le ${date}`;
   }
 
   if (type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT) {

--- a/apps/frontend/src/components/requestId/processing/StepNote.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepNote.tsx
@@ -81,7 +81,7 @@ export const StepNote = ({
             <>
               <span>par </span>
               <span className="fr-text--bold">
-                {capitalizeFirst(author.prenom)} {capitalizeFirst(author.nom)}
+                {capitalizeFirst(author.prenom)} <span className="lastname">{author.nom}</span>
               </span>
             </>
           )}

--- a/apps/frontend/src/components/requestId/requestInfos.tsx
+++ b/apps/frontend/src/components/requestId/requestInfos.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox';
 import type { RequetePrioriteType } from '@sirena/common/constants';
 import { REQUETE_STATUT_TYPES } from '@sirena/common/constants';
+import type { ReactNode } from 'react';
 import { useUpdatePriorite } from '@/hooks/mutations/updatePriorite.hook';
 import { useUpdateStatut } from '@/hooks/mutations/updateStatut.hook';
 import { useProfile } from '@/hooks/queries/profile.hook';
@@ -13,7 +14,7 @@ import { ContactInfo } from './sections/helpers';
 
 interface RequestInfosProps {
   requestId?: string;
-  fullName: string | null;
+  fullName: ReactNode;
   motifs: string[];
   statutId: string;
   prioriteId?: string | null;

--- a/apps/frontend/src/components/requestId/sections/DeclarantSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/DeclarantSection.tsx
@@ -22,7 +22,7 @@ export const DeclarantSection = ({ requestId, id, declarant, editHref }: Declara
       ? {
           civilite: declarantIdentite.civiliteId ? { label: declarantIdentite.civiliteId } : undefined,
           prenom: declarantIdentite.prenom,
-          nom: declarantIdentite.nom?.toUpperCase() || '',
+          nom: declarantIdentite.nom || '',
         }
       : null,
   );

--- a/apps/frontend/src/components/requestId/sections/PersonneConcerneeSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/PersonneConcerneeSection.tsx
@@ -22,7 +22,7 @@ export const PersonneConcerneeSection = ({ requestId, id, personne, editHref }: 
       ? {
           civilite: personneIdentite.civiliteId ? { label: personneIdentite.civiliteId } : undefined,
           prenom: personneIdentite.prenom,
-          nom: personneIdentite.nom?.toUpperCase() || '',
+          nom: personneIdentite.nom || '',
         }
       : null,
   );

--- a/apps/frontend/src/components/requestId/sections/SituationSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/SituationSection.tsx
@@ -86,12 +86,28 @@ const getLieuDeSurvenue = (situation: SituationData) => {
   return text;
 };
 
-const getMisEnCauseIdentity = (misEnCause: SituationData['misEnCause'] | undefined | null): string => {
-  if (!misEnCause) return '';
+const getMisEnCauseIdentity = (misEnCause: SituationData['misEnCause'] | undefined | null): React.ReactNode => {
+  if (!misEnCause) return null;
   if (misEnCause.nomService) return misEnCause.nomService;
-  const identity = [misEnCause.civilite, misEnCause.prenom, misEnCause.nom].filter(Boolean).join(' ').trim();
-  if (identity) return identity;
-  return misEnCause.commentaire || '';
+  const { civilite, prenom, nom } = misEnCause;
+  if (civilite || prenom || nom) {
+    const parts: React.ReactNode[] = [];
+    if (civilite) parts.push(civilite);
+    if (prenom) parts.push(prenom);
+    if (nom) parts.push(<span className="lastname">{nom}</span>);
+    return (
+      <>
+        {parts.map((part, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+          <span key={index}>
+            {index > 0 ? ' ' : ''}
+            {part}
+          </span>
+        ))}
+      </>
+    );
+  }
+  return misEnCause.commentaire || null;
 };
 
 const Affectations = ({ situation }: { situation?: SituationData | null }) => {
@@ -262,16 +278,25 @@ export const SituationSection = ({ id, requestId, situation, receptionType, edit
           </div>
         )}
 
-        {hasMisEnCause && (
-          <div className="fr-col-auto">
-            <p className={fr.cx('fr-mb-0')}>
-              <span className={fr.cx('fr-icon-error-warning-line', 'fr-icon--sm')} aria-hidden="true" />
-              <span className="fr-sr-only">Identité de la personne concernée :</span>{' '}
-              {getMisEnCauseIdentity(situation?.misEnCause) && `${getMisEnCauseIdentity(situation?.misEnCause)} - `}
-              {situation?.misEnCause?.misEnCauseType?.label}
-            </p>
-          </div>
-        )}
+        {hasMisEnCause &&
+          (() => {
+            const identity = getMisEnCauseIdentity(situation?.misEnCause);
+            return (
+              <div className="fr-col-auto">
+                <p className={fr.cx('fr-mb-0')}>
+                  <span className={fr.cx('fr-icon-error-warning-line', 'fr-icon--sm')} aria-hidden="true" />
+                  <span className="fr-sr-only">Identité de la personne concernée :</span>{' '}
+                  {identity && (
+                    <>
+                      {identity}
+                      {' - '}
+                    </>
+                  )}
+                  {situation?.misEnCause?.misEnCauseType?.label}
+                </p>
+              </div>
+            );
+          })()}
 
         <div className="fr-col-auto">
           <MotifsQualified situation={situation} />

--- a/apps/frontend/src/components/requestId/sections/helpers.tsx
+++ b/apps/frontend/src/components/requestId/sections/helpers.tsx
@@ -3,11 +3,29 @@ import type { JSX } from 'react/jsx-runtime';
 
 export const capitalizeFirst = (str: string) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 
-export const formatFullName = (identite?: { civilite?: { label?: string }; prenom?: string; nom?: string } | null) => {
-  if (!identite) return '';
+export const formatFullName = (
+  identite?: { civilite?: { label?: string }; prenom?: string; nom?: string } | null,
+): JSX.Element | null => {
+  if (!identite) return null;
   const civiliteLabel = identite.civilite?.label;
   const formattedCivilite = civiliteLabel ? (civiliteLabel === 'M' ? `${civiliteLabel}.` : civiliteLabel) : '';
-  return [formattedCivilite, identite.nom, identite.prenom].filter(Boolean).join(' ');
+  const parts: Array<{ key: string; node: JSX.Element | string }> = [];
+  if (formattedCivilite) parts.push({ key: 'civilite', node: formattedCivilite });
+  if (identite.nom) parts.push({ key: 'nom', node: <span className="lastname">{identite.nom}</span> });
+  if (identite.prenom) parts.push({ key: 'prenom', node: identite.prenom });
+  if (parts.length === 0) return null;
+
+  return (
+    <>
+      {parts.map((part, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: parts are conditional; index disambiguates position
+        <span key={`${part.key}-${index}`}>
+          {index > 0 ? ' ' : ''}
+          {part.node}
+        </span>
+      ))}
+    </>
+  );
 };
 
 export const formatAddress = (

--- a/apps/frontend/src/styles/main.css
+++ b/apps/frontend/src/styles/main.css
@@ -96,3 +96,7 @@ body {
 .bold {
   font-weight: 700;
 }
+
+.lastname {
+  text-transform: uppercase;
+}


### PR DESCRIPTION
Introduce a .lastname span and CSS rule to uppercase surnames. Convert several name helpers to return ReactNode/JSX (formatFullName, getMisEnCauseIdentity, buildIdentity, toStringItem) and adapt cells/ components to consume nodes instead of plain strings. Add renderInlineNodeList for rendering node lists and use uniqueBy on keys. Remove ad-hoc nom.toUpperCase() calls and centralize casing in CSS.