### PR TITLE
feat: refine Requête PDF generation and labels

### DIFF
--- a/apps/backend/src/features/requetesEntite/requetesEntite.pdf.builder.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.pdf.builder.ts
@@ -43,6 +43,7 @@ export class RequetePdfBuilder {
   private readonly doc: TaggedPDFDocument;
   private readonly docElement: PDFStructureElement;
   private currentSection: PDFStructureElement | null = null;
+  private isFirstSubsectionInSection = true;
 
   constructor(title: string) {
     this.doc = new PDFDocument({
@@ -142,8 +143,8 @@ export class RequetePdfBuilder {
     this.docElement.add(
       this.doc.struct('H1', [
         () => {
-          this.doc.fontSize(16).font('Roboto-Bold').text(text, { align: 'center' });
-          this.doc.moveDown(0.4);
+          this.doc.fontSize(18).font('Roboto-Bold').text(text, { align: 'center' });
+          this.doc.moveDown(0.6);
         },
       ]),
     );
@@ -155,18 +156,19 @@ export class RequetePdfBuilder {
     const sect = this.doc.struct('Sect');
     this.docElement.add(sect);
     this.currentSection = sect;
+    this.isFirstSubsectionInSection = true;
 
     sect.add(
       this.doc.struct('H2', [
         () => {
-          this.doc.moveDown(0.5).fontSize(13).font('Roboto-Bold').text(title);
+          this.doc.moveDown(0.9).fontSize(15).font('Roboto-Bold').text(title);
           this.doc.markContent('Artifact', { type: 'Layout' });
           this.doc
             .moveTo(this.doc.page.margins.left, this.doc.y)
             .lineTo(this.doc.page.width - this.doc.page.margins.right, this.doc.y)
             .stroke();
           this.doc.endMarkedContent();
-          this.doc.moveDown(0.3);
+          this.doc.moveDown(0.5);
         },
       ]),
     );
@@ -174,11 +176,14 @@ export class RequetePdfBuilder {
   }
 
   subsection(title: string): this {
+    const isFirst = this.isFirstSubsectionInSection;
+    this.isFirstSubsectionInSection = false;
     this.current.add(
       this.doc.struct('H3', [
         () => {
-          this.doc.moveDown(0.3).fontSize(11).font('Roboto-Bold').text(title);
-          this.doc.moveDown(0.2);
+          if (!isFirst) this.doc.moveDown(0.7);
+          this.doc.fontSize(13).font('Roboto-Bold').text(title, { underline: true });
+          this.doc.moveDown(0.4);
         },
       ]),
     );
@@ -193,6 +198,7 @@ export class RequetePdfBuilder {
             .fontSize(12)
             .font(options?.bold ? 'Roboto-Bold' : 'Roboto')
             .text(text);
+          this.doc.moveDown(0.2);
         },
       ]),
     );
@@ -206,6 +212,7 @@ export class RequetePdfBuilder {
         () => {
           this.doc.fontSize(12).font('Roboto-Bold').text(`${label} : `, { continued: true });
           this.doc.font('Roboto').text(value);
+          this.doc.moveDown(0.2);
         },
       ]),
     );
@@ -239,6 +246,7 @@ export class RequetePdfBuilder {
     }
 
     list.end();
+    this.doc.moveDown(0.3);
     return this;
   }
 
@@ -302,6 +310,7 @@ export class RequetePdfBuilder {
     }
 
     list.end();
+    this.doc.moveDown(0.3);
     return this;
   }
 

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -12,6 +12,7 @@ import {
   type RequeteStatutType,
 } from '@sirena/common/constants';
 import type { DeclarantDataSchema, PersonneConcerneeDataSchema, SituationDataSchema } from '@sirena/common/schemas';
+import { getLieuPrecisionLabel } from '@sirena/common/utils';
 import archiver from 'archiver';
 import type { z } from 'zod';
 import { getOriginalFileName } from '../../helpers/file.js';
@@ -2040,41 +2041,11 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
   const pdf = new RequetePdfBuilder(`Requête ${requete.id}`);
 
   // ===== 1. HEADERS =====
-  const allMaltraitanceTypes = (requete.situations ?? [])
-    .flatMap(
-      (s) =>
-        s.faits?.[0]?.maltraitanceTypes
-          ?.filter((mt) => mt.maltraitanceType.id !== 'NON')
-          .map((mt) => `${mt.maltraitanceType.label} (maltraitance)`) ?? [],
-    )
-    .filter((v, i, arr) => arr.indexOf(v) === i);
-
-  const allMotifsDeclaratifs = [
-    ...allMaltraitanceTypes,
-    ...(requete.situations ?? [])
-      .flatMap((s) => s.faits?.[0]?.motifsDeclaratifs?.map((m) => m.motifDeclaratif.label) ?? [])
-      .filter((v, i, arr) => arr.indexOf(v) === i),
-  ];
-
-  const allMotifsQualifies = (requete.situations ?? []).flatMap((s) => s.faits?.[0]?.motifs ?? []);
-  const allMotifsGrouped = groupMotifsByParent(allMotifsQualifies);
-
   pdf
     .h1(`Requête ${requete.id}`)
     .field('Statut', requeteEntite.statut?.label || requeteEntite.statutId)
-    .field('Priorité', requeteEntite.priorite?.label || null);
-
-  if (allMotifsDeclaratifs.length > 0) {
-    pdf.paragraph('Motifs renseignés par le déclarant :', { bold: true });
-    pdf.list(allMotifsDeclaratifs);
-  }
-
-  if (allMotifsGrouped.length > 0) {
-    pdf.paragraph('Motifs qualifiés :', { bold: true });
-    pdf.groupedList(allMotifsGrouped);
-  }
-
-  pdf.field('Date de génération', formatDateFr(new Date()));
+    .field('Priorité', requeteEntite.priorite?.label || null)
+    .field('Date de génération', formatDateFr(new Date()));
 
   // ===== 2. REQUÊTE ORIGINALE =====
   pdf
@@ -2096,9 +2067,8 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
         .field('Civilité', d.identite?.civilite?.label || null)
         .field('Prénom', d.identite?.prenom || null)
         .field('Nom', d.identite?.nom || null)
-        .field('Lien avec la victime', d.lienVictime?.label || null)
+        .field('Lien avec la personne concernée', d.lienVictime?.label || null)
         .field('Précision lien', d.lienAutrePrecision || null)
-        .field('Tuteur/Curateur', booleanLabel(d.isTuteur))
         .field('Adresse', formatRue(d.adresse))
         .field('Code postal', d.adresse?.codePostal || null)
         .field('Ville', d.adresse?.ville || null)
@@ -2109,9 +2079,19 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
           booleanLabel(
             d.veutGarderAnonymat === null || d.veutGarderAnonymat === undefined ? null : !d.veutGarderAnonymat,
           ),
-        )
-        .field('Signalement professionnel (EIG)', booleanLabel(d.estSignalementProfessionnel))
-        .field('Autres précisions', d.commentaire || null);
+        );
+
+      if (d.isTuteur) {
+        pdf.paragraph('Le déclarant est curateur ou tuteur de la personne concernée');
+      }
+
+      if (d.estSignalementProfessionnel !== null && d.estSignalementProfessionnel !== undefined) {
+        pdf.paragraph(
+          `Le déclarant ${d.estSignalementProfessionnel ? 'est' : "n'est pas"} un professionnel qui signale des dysfonctionnements et évènements indésirables graves (EIG)`,
+        );
+      }
+
+      pdf.field('Autres précisions', d.commentaire || null);
     }
   }
 
@@ -2153,10 +2133,10 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
       pdf
         .subsection('Lieu de survenue')
         .field('Type de lieu', lieu.lieuType?.label || null)
-        .field('Précision du lieu', lieu.lieuPrecision || null)
+        .field('Précision du lieu', getLieuPrecisionLabel(lieu.lieuType?.id, lieu.lieuPrecision) || null)
         .field('Rue', formatRue(lieu.adresse))
-        .field('Code postal', lieu.adresse?.codePostal || lieu.codePostal || null)
-        .field('Ville', lieu.adresse?.ville || null)
+        .field('Code postal renseigné par le déclarant', lieu.codePostal || null)
+        .field('Ville', `${lieu.adresse?.codePostal || ''} ${lieu.adresse?.ville || ''}`.trim() || null)
         .field("Nom de l'établissement", lieu.adresse?.label || lieu.categLib || null)
         .field('Numéro FINESS', lieu.finess || null)
         .field('Société de transport', lieu.societeTransport || null);

--- a/apps/frontend/src/components/requestId/sections/SituationSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/SituationSection.tsx
@@ -322,7 +322,7 @@ export const SituationSection = ({ id, requestId, situation, receptionType, edit
             </p>
             {situation?.lieuDeSurvenue.codePostal && (
               <p className={fr.cx('fr-mb-1w')}>
-                <span>Code postal :</span> {situation.lieuDeSurvenue.codePostal}
+                <span>Code postal renseigné par le déclarant :</span> {situation.lieuDeSurvenue.codePostal}
               </p>
             )}
             {situation?.lieuDeSurvenue?.lieuPrecision && (
@@ -353,7 +353,7 @@ export const SituationSection = ({ id, requestId, situation, receptionType, edit
               ))}
             {situation?.lieuDeSurvenue?.adresse?.codePostal && situation?.lieuDeSurvenue?.adresse?.ville && (
               <p className={fr.cx('fr-mb-2w')}>
-                <span>Code postal :</span> {situation.lieuDeSurvenue.adresse.codePostal}{' '}
+                <span>Ville :</span> {situation.lieuDeSurvenue.adresse.codePostal}{' '}
                 {situation.lieuDeSurvenue.adresse.ville}
               </p>
             )}


### PR DESCRIPTION
Import getLieuPrecisionLabel and use it for lieu precision Remove aggregated "motifs" lists from header
Rename "Lien avec la victime" to "Lien avec la personne concernée" Render tuteur/curateur and EIG as explanatory
paragraphs instead of booleans
Prefer lieu.codePostal over adresse.codePostal when present