### PR TITLE
fix(SIRENA-393): RGAA correction PrioriteMenu 

### DIFF
--- a/apps/frontend/src/components/common/PrioriteMenu.module.css
+++ b/apps/frontend/src/components/common/PrioriteMenu.module.css
@@ -1,25 +1,32 @@
-.priorite-menu-trigger {
-  font-size: 0.75rem;
-  line-height: 1.5rem;
-  padding: 0.25rem 0.5rem;
-  min-height: 1.5rem;
-  height: auto;
+.priorite-filter {
+  position: relative;
+  display: inline-block;
+}
+
+.priorite-filter__button {
   display: inline-flex;
   align-items: center;
-  box-sizing: border-box;
+  gap: 0.25rem;
+  white-space: nowrap;
+  cursor: pointer;
 }
 
-.priorite-haute {
-  color: var(--text-default-warning);
-  background-color: var(--background-contrast-warning);
+.priorite-filter__dropdown {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  padding: 1rem;
+
+  background: var(--background-default-grey);
+  border-radius: var(--radius-1);
+  border-top: none;
+  box-shadow: var(--shadow-overlap);
+  z-index: 1000;
+  background-color: var(--background-default-grey);
 }
 
-.priorite-moyenne {
-  color: var(--brown-opera-200-100);
-  background-color: var(--brown-opera-950-100);
-}
-
-.priorite-basse {
-  color: var(--green-tilleul-verveine-75-active);
-  background-color: var(--green-tilleul-verveine-975-75);
+.button-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }

--- a/apps/frontend/src/components/common/PrioriteMenu.tsx
+++ b/apps/frontend/src/components/common/PrioriteMenu.tsx
@@ -1,78 +1,92 @@
-import { REQUETE_PRIORITE_TYPES } from '@sirena/common/constants';
-import { Menu } from '@sirena/ui';
-import { useState } from 'react';
+import { RadioButtons } from '@codegouvfr/react-dsfr/RadioButtons';
+import { REQUETE_PRIORITE_TYPES, type RequetePrioriteType } from '@sirena/common/constants';
+import { useId } from 'react';
+import { useDisclosureMenu } from '@/hooks/useDisclosureMenu';
 import { requetePrioriteBadges } from '@/utils/requeteStatutBadge.constant';
 import prioriteStyles from './PrioriteMenu.module.css';
-import styles from './statusMenu.module.css';
+import { RequetePrioriteTag } from './RequeteStatutTag';
 
 type PrioriteMenuProps = {
-  onPrioriteClick?: (value: string | null) => void;
-  isLoading?: boolean;
-  disabled?: boolean;
   value: string | null;
+  onChange: (value: string | null) => void;
+  disabled?: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
 };
 
-export const PrioriteMenu = ({ value, onPrioriteClick, isLoading, disabled }: PrioriteMenuProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+export function PrioriteMenu({ value, onChange, disabled, onOpen, onClose }: PrioriteMenuProps) {
+  const { isOpen, toggle, triggerRef, panelRef, onPanelBlur } = useDisclosureMenu({ onOpen, onClose });
 
-  const badgeSelected = value ? requetePrioriteBadges.find((badge) => badge.value === value) : null;
+  const menuId = useId();
+
+  const badgeSelected = requetePrioriteBadges.find((b) => b.value === value);
+  const label = badgeSelected ? 'Modifier la priorité :' : 'Définir une priorité';
+
   const prioriteClassMap: Record<string, string> = {
     [REQUETE_PRIORITE_TYPES.HAUTE]: prioriteStyles['priorite-haute'],
     [REQUETE_PRIORITE_TYPES.MOYENNE]: prioriteStyles['priorite-moyenne'],
     [REQUETE_PRIORITE_TYPES.BASSE]: prioriteStyles['priorite-basse'],
   };
-  const badgeSelectedClassName =
-    value && badgeSelected ? prioriteClassMap[value] || `fr-badge--${badgeSelected.type}` : '';
-  const badgeSelectedText = badgeSelected ? `Priorité : ${badgeSelected.text}` : 'Définir une priorité';
 
-  const badgesFiltred = requetePrioriteBadges.filter((badge) => badge.value !== value);
-
-  const handleClick = (badgeValue: string) => {
-    onPrioriteClick?.(badgeValue);
-    setIsOpen(false);
-  };
-
-  const handleClear = () => {
-    onPrioriteClick?.(null);
-    setIsOpen(false);
-  };
+  const options = [
+    ...requetePrioriteBadges.map((badge) => ({
+      label: badge.text,
+      className: prioriteClassMap[badge.value],
+      nativeInputProps: {
+        value: badge.value,
+        checked: value === badge.value,
+        onChange: () => onChange(badge.value),
+      },
+    })),
+    {
+      label: 'Aucune',
+      nativeInputProps: {
+        value: '',
+        checked: value === null,
+        onChange: () => onChange(null),
+      },
+    },
+  ];
 
   return (
-    <Menu.Root onOpenChange={setIsOpen}>
-      <Menu.Trigger
-        isOpen={isOpen}
-        isLoading={isLoading}
+    <div className={prioriteStyles['priorite-filter']}>
+      <button
+        type="button"
         disabled={disabled}
-        className={`fr-badge fr-badge--no-icon fr-badge--sm ${badgeSelectedClassName} ${prioriteStyles['priorite-menu-trigger']}`}
+        className="fr-btn fr-btn--tertiary"
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        onClick={toggle}
+        ref={triggerRef}
       >
-        {badgeSelectedText}
-      </Menu.Trigger>
-      <Menu.Portal>
-        <Menu.Positioner align="start">
-          <Menu.Popup className={styles['status-menu']}>
-            {value && (
-              <Menu.Item
-                className={`${styles['status-menu__item']} fr-badge fr-badge--no-icon fr-badge--sm`}
-                onClick={handleClear}
-              >
-                Définir une priorité
-              </Menu.Item>
+        {badgeSelected ? (
+          <span className={prioriteStyles['button-content']}>
+            <span>{label}</span>
+            {badgeSelected && (
+              <>
+                <span className="fr-sr-only">Priorité actuelle :</span>
+                <RequetePrioriteTag statut={value as RequetePrioriteType} noIcon />
+              </>
             )}
-            {badgesFiltred.map((badge) => {
-              const badgeClassName = prioriteClassMap[badge.value] || `fr-badge--${badge.type}`;
-              return (
-                <Menu.Item
-                  key={badge.value}
-                  className={`${styles['status-menu__item']} fr-badge fr-badge--no-icon fr-badge--sm ${badgeClassName}`}
-                  onClick={() => handleClick(badge.value)}
-                >
-                  {badge.text}
-                </Menu.Item>
-              );
-            })}
-          </Menu.Popup>
-        </Menu.Positioner>
-      </Menu.Portal>
-    </Menu.Root>
+          </span>
+        ) : (
+          'Définir une priorité'
+        )}
+        <span
+          aria-hidden="true"
+          className={`fr-icon-arrow-down-s-line menu__trigger__icon${isOpen ? ' menu__trigger__icon--is-open' : ''}`}
+        />
+      </button>
+      {isOpen && (
+        <div
+          id={menuId}
+          ref={panelRef}
+          className={prioriteStyles['priorite-filter__dropdown']}
+          onBlurCapture={onPanelBlur}
+        >
+          <RadioButtons legend="Choisir une priorité" name={`priorite-${menuId}`} options={options} />
+        </div>
+      )}
+    </div>
   );
-};
+}

--- a/apps/frontend/src/components/common/RequeteStatutTag.tsx
+++ b/apps/frontend/src/components/common/RequeteStatutTag.tsx
@@ -1,12 +1,10 @@
 import Badge from '@codegouvfr/react-dsfr/Badge';
-import { REQUETE_PRIORITE_TYPES } from '@sirena/common/constants';
 import {
   requeteEtapeStatutBadges,
   requetePrioriteBadges,
   requeteStatutBadges,
   type StatutBadge,
 } from '@/utils/requeteStatutBadge.constant';
-import prioriteStyles from './PrioriteMenu.module.css';
 
 type Props = {
   statut: string;
@@ -34,24 +32,15 @@ export const RequeteStatutTag = StatutTag(requeteStatutBadges);
 
 export const RequeteEtapeStatutTag = StatutTag(requeteEtapeStatutBadges);
 
-export const RequetePrioriteTag = ({ statut, noIcon, className = '' }: Props) => {
+export const RequetePrioriteTag = ({ statut, noIcon }: Props) => {
   const badge = requetePrioriteBadges.find((badge) => badge.value === statut);
 
   if (!badge) {
     return null;
   }
 
-  const prioriteClassMap: Record<string, string> = {
-    [REQUETE_PRIORITE_TYPES.HAUTE]: prioriteStyles['priorite-haute'],
-    [REQUETE_PRIORITE_TYPES.MOYENNE]: prioriteStyles['priorite-moyenne'],
-    [REQUETE_PRIORITE_TYPES.BASSE]: prioriteStyles['priorite-basse'],
-  };
-
-  const prioriteClassName = prioriteClassMap[statut] || '';
-  const combinedClassName = `${className} ${prioriteClassName}`.trim();
-
   return (
-    <Badge noIcon={noIcon} severity={badge.type} className={combinedClassName}>
+    <Badge noIcon={noIcon} severity={badge.type}>
       {badge.text}
     </Badge>
   );

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -147,7 +147,7 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                   className="fr-col"
                   style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.5rem' }}
                 >
-                  <h6 className="fr-mb-0">Traitement</h6>
+                  <h2 className="fr-mb-0 fr-text--xl">Traitement</h2>
                   {requestQuery.data && (
                     <>
                       <EntiteTypeBadge

--- a/apps/frontend/src/components/requestId/requestInfos.module.css
+++ b/apps/frontend/src/components/requestId/requestInfos.module.css
@@ -18,7 +18,41 @@
   text-overflow: ellipsis;
 }
 
+.request-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.request-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.request-left h1 {
+  margin: 0;
+}
+
+.download-menu-wrapper {
+  display: flex;
+  align-items: center;
+}
+.request-header h1 {
+  margin: 0;
+}
+
 .request-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.request-actions {
   display: flex;
   align-items: center;
   flex-wrap: wrap;

--- a/apps/frontend/src/components/requestId/requestInfos.tsx
+++ b/apps/frontend/src/components/requestId/requestInfos.tsx
@@ -59,46 +59,45 @@ export const RequestInfos = ({
       <div className="fr-col">
         <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
           <div className="fr-col">
-            <h1 className="fr-mb-2w">
-              {requestId ? (
-                <>
-                  <div className={style['request-title']}>
-                    <span>Requête {requestId}</span>
+            <div className={style['request-header']}>
+              <div className={style['request-left']}>
+                <h1>{requestId ? `Requête ${requestId}` : 'Nouvelle requête'}</h1>
+
+                {requestId && (
+                  <>
                     <RequeteStatutTag className={style['requete-statut-tag']} statut={statutId} noIcon />
                     <PrioriteMenu
                       value={prioriteId || null}
-                      onPrioriteClick={handlePrioriteChange}
-                      isLoading={updatePrioriteMutation.isPending}
+                      onChange={handlePrioriteChange}
                       disabled={!requestId || updatePrioriteMutation.isPending}
                     />
-                  </div>
-                  {showPriseEnCompteToggle && (
-                    <div className={`${style['toggle-line']} fr-text--md`}>
-                      <Checkbox
-                        options={[
-                          {
-                            label: 'Cette requête a été prise en compte',
-                            nativeInputProps: {
-                              checked: statutId === REQUETE_STATUT_TYPES.TRAITEE,
-                              onChange: (e) => handlePriseEnCompteChange(e.target.checked),
-                              disabled: updateStatutMutation.isPending,
+
+                    {showPriseEnCompteToggle && (
+                      <div className={`${style['toggle-line']} fr-text--md`}>
+                        <Checkbox
+                          options={[
+                            {
+                              label: 'Cette requête a été prise en compte',
+                              nativeInputProps: {
+                                checked: statutId === REQUETE_STATUT_TYPES.TRAITEE,
+                                onChange: (e) => handlePriseEnCompteChange(e.target.checked),
+                                disabled: updateStatutMutation.isPending,
+                              },
                             },
-                          },
-                        ]}
-                      />
-                    </div>
-                  )}
-                </>
-              ) : (
-                'Nouvelle requête'
+                          ]}
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+              {requestId && (
+                <div className={style['download-menu-wrapper']}>
+                  <DownloadMenu requestId={requestId} disabled={!hasAttachments} hasUnsafeFiles={hasUnsafeFiles} />
+                </div>
               )}
-            </h1>
-          </div>
-          {requestId && (
-            <div className={`fr-col-auto ${style['download-menu-wrapper']}`}>
-              <DownloadMenu requestId={requestId ?? ''} disabled={!hasAttachments} hasUnsafeFiles={hasUnsafeFiles} />
             </div>
-          )}
+          </div>
         </div>
         {fullName && (
           <div className={style['legend-display']}>

--- a/apps/frontend/src/hooks/useDisclosureMenu.ts
+++ b/apps/frontend/src/hooks/useDisclosureMenu.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type useDisclosureMenuOptions = {
+  onOpen?: () => void;
+  onClose?: () => void;
+};
+
+export function useDisclosureMenu({ onOpen, onClose }: useDisclosureMenuOptions = {}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    onOpen?.();
+  }, [onOpen]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    onClose?.();
+
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  }, [onClose]);
+
+  const toggle = useCallback(() => {
+    setIsOpen((v) => {
+      const next = !v;
+      next ? onOpen?.() : onClose?.();
+      return next;
+    });
+  }, [onOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+
+      if (
+        panelRef.current &&
+        triggerRef.current &&
+        !panelRef.current.contains(target) &&
+        !triggerRef.current.contains(target)
+      ) {
+        close();
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [isOpen, close]);
+
+  // fermeture si focus sort du panel (WCAG-safe)
+  const onPanelBlur = useCallback(
+    (e: React.FocusEvent<HTMLElement>) => {
+      const next = e.relatedTarget as Node | null;
+
+      if (!next || !panelRef.current?.contains(next)) {
+        close();
+      }
+    },
+    [close],
+  );
+
+  return {
+    isOpen,
+    open,
+    close,
+    toggle,
+    triggerRef,
+    panelRef,
+    onPanelBlur,
+  };
+}


### PR DESCRIPTION
Refacto du composant `PrioriteMenu`

* Remplacement de l’ancien composant par un pattern **bouton + panneau dépliant**
* Utilisation de `RadioButtons` (DSFR) → rendu natif avec `<fieldset>` / `<legend>`
* Suppression de la logique custom fragile (gestion clavier / focus)
* Amélioration de la sémantique et conformité RGAA/WCAG

Mise à jour du design (vu avec Axelle) pour améliorer la compréhension et intitulé de boutons pertinents 

Ajout du hook `useDisclosureMenu`

* Centralisation de la logique d’ouverture/fermeture pour composants type "menu" :

  * toggle
  * fermeture au clic extérieur
  * fermeture avec `Escape`
  * fermeture à la perte de focus (WCAG safe)
* Gestion du focus (retour au bouton à la fermeture)
* Réutilisable pour d’autres filtres (ex: `DepartementFilter` -> autre PR ) 
-> Implémentation basée sur le pattern disclosure (bouton + panneau) avec éléments natifs (fieldset, input)

Ce hook permet d’éviter l’utilisation de patterns role="menu" inadaptés pour des composants de type formulaire (cf. https://access42.net/motif-conception-aria-menu/), et garantit une implémentation plus conforme RGAA/WCAG.



