### PR TITLE
fix(sirena-552): remove requetes list from menu for super admins

### DIFF
--- a/apps/frontend/src/components/layout/userMenu.test.tsx
+++ b/apps/frontend/src/components/layout/userMenu.test.tsx
@@ -81,10 +81,9 @@ describe('UserMenu', () => {
     expect(link).toBeInTheDocument();
   });
 
-  it('shows a "Liste des requêtes" entry for super admins inside the admin area', async () => {
+  it('does not show a "Liste des requêtes" entry for super admins inside the admin area', async () => {
     await renderUserMenu({ roleId: ROLES.SUPER_ADMIN, isAdminRoute: true });
 
-    const link = screen.getByRole('link', { name: 'Liste des requêtes' });
-    expect(link).toHaveAttribute('href', '/home');
+    expect(screen.queryByRole('link', { name: 'Liste des requêtes' })).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/layout/userMenu.tsx
+++ b/apps/frontend/src/components/layout/userMenu.tsx
@@ -159,15 +159,17 @@ export const UserMenu = () => {
           {(role === ROLES.ENTITY_ADMIN || role === ROLES.SUPER_ADMIN) && (
             <>
               {isAdminRoute ? (
-                <a className="fr-btn--icon-left fr-icon-user-line fr-p-2w" href="/home">
-                  Liste des requêtes
-                </a>
+                role === ROLES.ENTITY_ADMIN && (
+                  <a className="fr-btn--icon-left fr-icon-user-line fr-p-2w" href="/home">
+                    Liste des requêtes
+                  </a>
+                )
               ) : (
                 <a className="fr-btn--icon-left fr-icon-settings-5-line fr-p-2w" href="/admin/users">
                   Espace administrateur
                 </a>
               )}
-              <div className="user-menu__separator" />
+              {(!isAdminRoute || role === ROLES.ENTITY_ADMIN) && <div className="user-menu__separator" />}
             </>
           )}
 


### PR DESCRIPTION
Removes item "requêtes list" from menu for super admins:
<img width="1126" height="421" alt="image" src="https://github.com/user-attachments/assets/61f458e7-f9bb-4859-998d-45f5873c17e3" />
