### PR TITLE
Nombreux fixs designs et fixs concernant la feature d'envoi d'accusee d'AR manuel

### DIFF
--- a/apps/backend/src/config/tipimail.constant.ts
+++ b/apps/backend/src/config/tipimail.constant.ts
@@ -1,6 +1,6 @@
 export const ACKNOWLEDGMENT_EMAIL_TEMPLATE_NAME = 'ar-declarant';
 export const ACKNOWLEDGMENT_EMAIL_TEMPLATE_ID = '6961329ca81eb359fc15df3c';
-export const ACKNOWLEDGMENT_EMAIL_SUBJECT = 'Accusé de réception de votre dossier';
+export const ACKNOWLEDGMENT_EMAIL_SUBJECT = 'Votre dossier a bien été reçu';
 export const NOTIFICATION_ENTITE_AFFECTATION_TEMPLATE_NAME = 'notification-entite-affectation';
 export const NOTIFICATION_SITUATION_ENTITE_TEMPLATE_NAME = 'notification-situation-affectation';
 

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -421,17 +421,20 @@ export async function sendManualAcknowledgmentEmail({
       logger.error({ requeteId, error: changelogError }, 'Failed to create changelog for manual acknowledgment email');
     }
   } catch (error) {
-    logger.error({ requeteId, entiteId, etapeId, error }, 'Failed to send manual acknowledgment email');
+    logger.error(
+      { requeteId, entiteId, etapeId, error },
+      'Failed to send manual acknowledgment email, rolling back step to A_FAIRE',
+    );
     try {
-      await prisma.requeteEtapeNote.create({
-        data: {
-          texte: "Erreur lors de l'envoi de l'e-mail d'accusé de réception. Veuillez contacter le support.",
-          authorId: null,
-          requeteEtapeId: etapeId,
-        },
+      await prisma.requeteEtape.update({
+        where: { id: etapeId },
+        data: { statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE },
       });
-    } catch (noteError) {
-      logger.error({ etapeId, error: noteError }, 'Failed to create error note on acknowledgment step');
+    } catch (rollbackError) {
+      logger.error(
+        { etapeId, error: rollbackError },
+        'Failed to rollback acknowledgment step status after send failure',
+      );
     }
     throw error;
   }

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -277,7 +277,7 @@ export function buildAcknowledgmentMessageText(
   const entiteAdmin = formatEntiteAdminString(entites);
   const entiteComplete = formatEntiteCompleteString(entites);
   return [
-    `Votre dossier a bien été reçu sous le numéro ${requeteId}.`,
+    `Bonjour, votre dossier a bien été reçu sous le numéro ${requeteId}.`,
     `Merci d'avoir pris le temps de partager ces informations.`,
     `Il est désormais suivi par ${entiteAdmin}.`,
     '',

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -15,7 +15,6 @@ import { uploadFileToMinio } from '../../libs/minio.js';
 import { type Prisma, prisma, type UploadedFile } from '../../libs/prisma.js';
 import { createChangeLog } from '../changelog/changelog.service.js';
 import { ChangeLogAction } from '../changelog/changelog.type.js';
-import { getEntitesByRequeteId } from '../entites/entites.service.js';
 import { updateAcknowledgmentStep } from '../requeteEtapes/requetesEtapes.service.js';
 import { createUploadedFile } from '../uploadedFiles/uploadedFiles.service.js';
 
@@ -326,13 +325,24 @@ export async function sendManualAcknowledgmentEmail({
   logger.info({ requeteId, entiteId, etapeId }, 'Acknowledgment step claimed, proceeding to send email');
 
   try {
-    const [declarantResult, entites] = await Promise.all([
+    const [declarantResult, entite] = await Promise.all([
       prisma.requete.findUnique({
         where: { id: requeteId },
         include: { declarant: { include: { identite: true } } },
       }),
-      getEntitesByRequeteId(requeteId),
+      prisma.entite.findUnique({
+        where: { id: entiteId },
+        select: {
+          id: true,
+          nomComplet: true,
+          emailContactUsager: true,
+          telContactUsager: true,
+          adresseContactUsager: true,
+          entiteMereId: true,
+        },
+      }),
     ]);
+    const entites = entite ? [entite] : [];
 
     const declarantEmail = declarantResult?.declarant?.identite?.email;
     if (!declarantEmail) {

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
@@ -6,8 +6,10 @@ import {
 } from '@sirena/backend-utils/helpers';
 import { REQUETE_ETAPE_STATUT_TYPES, REQUETE_ETAPE_TYPES, REQUETE_STATUT_TYPES, ROLES } from '@sirena/common/constants';
 import { validator as zValidator } from 'hono-openapi';
+import { ACKNOWLEDGMENT_EMAIL_SUBJECT } from '../../config/tipimail.constant.js';
 import factoryWithLogs from '../../helpers/factories/appWithLogs.js';
 import { streamFileResponse, streamSafeFileResponse } from '../../helpers/file.js';
+import { prisma } from '../../libs/prisma.js';
 import authMiddleware from '../../middlewares/auth.middleware.js';
 import requeteEtapesChangelogMiddleware from '../../middlewares/changelog/changelog.requeteEtape.middleware.js';
 import entitesMiddleware from '../../middlewares/entites.middleware.js';
@@ -18,7 +20,6 @@ import {
   buildAcknowledgmentMessageText,
   sendManualAcknowledgmentEmail,
 } from '../declarants/declarants.notification.service.js';
-import { getEntitesByRequeteId } from '../entites/entites.service.js';
 import {
   getRequeteEntiteById,
   hasAccessToRequete,
@@ -438,15 +439,27 @@ const app = factoryWithLogs
       throwHTTPException403Forbidden('You are not allowed to access this requete', { res: c.res });
     }
 
-    const entites = await getEntitesByRequeteId(requeteEtape.requeteId);
+    const [entite, requete] = await Promise.all([
+      prisma.entite.findUnique({
+        where: { id: topEntiteId },
+        select: {
+          id: true,
+          nomComplet: true,
+          emailContactUsager: true,
+          telContactUsager: true,
+          adresseContactUsager: true,
+          entiteMereId: true,
+        },
+      }),
+      getRequeteEntiteById(requeteEtape.requeteId, topEntiteId),
+    ]);
+    const entites = entite ? [entite] : [];
     const message = buildAcknowledgmentMessageText(requeteEtape.requeteId, entites);
-
-    const requete = await getRequeteEntiteById(requeteEtape.requeteId, topEntiteId);
     const declarantEmail = requete?.requete?.declarant?.identite?.email ?? null;
 
     logger.info({ requeteEtapeId: id }, 'Acknowledgment message preview fetched');
 
-    return c.json({ data: { message, declarantEmail } });
+    return c.json({ data: { message, declarantEmail, subject: ACKNOWLEDGMENT_EMAIL_SUBJECT } });
   })
 
   .post(

--- a/apps/frontend/src/components/common/statusMenu.tsx
+++ b/apps/frontend/src/components/common/statusMenu.tsx
@@ -25,12 +25,17 @@ export const StatusMenu = ({ badges, value, onBadgeClick, isLoading, disabled }:
 
   const badgesFiltred = badges.filter((badge) => badge.value !== value);
 
+  if (disabled) {
+    return (
+      <span className={`fr-badge fr-badge--no-icon fr-badge--sm ${badgeSelectedClassName}`}>{badgeSelectedText}</span>
+    );
+  }
+
   return (
     <Menu.Root onOpenChange={setIsOpen}>
       <Menu.Trigger
         isOpen={isOpen}
         isLoading={isLoading}
-        disabled={disabled}
         className={`fr-badge fr-badge--no-icon fr-badge--sm ${badgeSelectedClassName}`}
       >
         {badgeSelectedText}

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -84,7 +84,8 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
               const isDisabled =
                 index === data.data.length - 1 ||
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ||
-                isAutomaticallyUpdated;
+                isAutomaticallyUpdated ||
+                (step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT);
               const isAcknowledgmentSendable =
                 !isDematSocialRequest &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.module.css
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.module.css
@@ -1,0 +1,41 @@
+.layout {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.scrollArea {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 16px 88px 16px;
+}
+
+.emailField {
+  background: #fff;
+  border: 1px solid #929292;
+  border-radius: 4px;
+  padding: 8px 12px;
+  min-height: 2rem;
+  overflow-x: auto;
+  white-space: nowrap;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #161616;
+}
+
+.subject {
+  color: #161616;
+}
+
+.messageField {
+  background: #fff;
+  border: 1px solid #929292;
+  border-radius: 4px;
+  padding: 8px 12px;
+  overflow-y: auto;
+  max-height: 320px;
+  white-space: pre-wrap;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #161616;
+}

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -159,23 +159,29 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                   ) : (
                     <form>
                       <div className="fr-form-group fr-mb-2w">
-                        <p className="fr-label fr-mb-1w">
-                          Adresse électronique du déclarant
-                          <span className="fr-hint-text">
-                            Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les informations
-                            déclarant.
-                          </span>
-                        </p>
-                        <div className={drawerStyles.emailField}>{declarantEmail}</div>
+                        <dl>
+                          <dt className="fr-label fr-mb-1w">
+                            Adresse électronique du déclarant
+                            <span className="fr-hint-text">
+                              Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les
+                              informations déclarant.
+                            </span>
+                          </dt>
+                          <dd className={drawerStyles.emailField}>{declarantEmail}</dd>
+                        </dl>
                       </div>
                       <div className="fr-form-group fr-mb-2w">
                         <p className="fr-label fr-mb-1w">
                           Ce message est généré automatiquement et ne peut pas être modifié
                         </p>
-                        <p className={`fr-text--sm fr-mb-1w ${drawerStyles.subject}`}>
-                          <strong>Objet :</strong> {subject}
-                        </p>
-                        <div className={drawerStyles.messageField}>{message}</div>
+                        <dl>
+                          <dt className={`fr-text--sm fr-mb-1w ${drawerStyles.subject}`}>
+                            <span className="fr-text--bold">Objet :</span>
+                          </dt>
+                          <dd className={`fr-text--sm fr-mb-1w ${drawerStyles.subject}`}>{subject}</dd>
+                          <dt className="fr-sr-only">Message</dt>
+                          <dd className={drawerStyles.messageField}>{message}</dd>
+                        </dl>
                       </div>
                       <Input
                         label="Commentaire personnalisé (facultatif)"

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -29,6 +29,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
     const [isOpen, setIsOpen] = useState(false);
     const [step, setStep] = useState<StepType | null>(null);
     const [declarantEmail, setDeclarantEmail] = useState('');
+    const [subject, setSubject] = useState('');
     const [message, setMessage] = useState('');
     const [comment, setComment] = useState('');
     const [isLoadingMessage, setIsLoadingMessage] = useState(false);
@@ -50,6 +51,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
     const handleReset = () => {
       setStep(null);
       setDeclarantEmail('');
+      setSubject('');
       setMessage('');
       setComment('');
       setIsLoadingMessage(false);
@@ -64,6 +66,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
       try {
         const data = await fetchAcknowledgmentMessage(s.id);
         setDeclarantEmail(data.declarantEmail ?? '');
+        setSubject(data.subject);
         setMessage(data.message);
       } catch {
         toastManager.add({
@@ -166,25 +169,55 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                     <p className="fr-text--sm fr-text-mention--grey">Chargement du message...</p>
                   ) : (
                     <form>
-                      <Input
-                        label="Adresse électronique du déclarant"
-                        hintText="Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les informations déclarant."
-                        nativeInputProps={{
-                          value: declarantEmail,
-                          readOnly: true,
-                          'aria-readonly': true,
-                        }}
-                      />
-                      <Input
-                        label="Ce message est généré automatiquement et ne peut pas être modifié"
-                        textArea={true}
-                        nativeTextAreaProps={{
-                          rows: 14,
-                          value: message,
-                          readOnly: true,
-                          'aria-readonly': true,
-                        }}
-                      />
+                      <div className="fr-form-group fr-mb-2w">
+                        <p className="fr-label fr-mb-1w">
+                          Adresse électronique du déclarant
+                          <span className="fr-hint-text">
+                            Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les informations
+                            déclarant.
+                          </span>
+                        </p>
+                        <div
+                          style={{
+                            background: '#fff',
+                            border: '1px solid #929292',
+                            borderRadius: '4px',
+                            padding: '8px 12px',
+                            minHeight: '2rem',
+                            overflowX: 'auto',
+                            whiteSpace: 'nowrap',
+                            fontSize: '1rem',
+                            lineHeight: '1.5rem',
+                            color: '#161616',
+                          }}
+                        >
+                          {declarantEmail}
+                        </div>
+                      </div>
+                      <div className="fr-form-group fr-mb-2w">
+                        <p className="fr-label fr-mb-1w">
+                          Ce message est généré automatiquement et ne peut pas être modifié
+                        </p>
+                        <p className="fr-text--sm fr-mb-1w" style={{ color: '#161616' }}>
+                          <strong>Objet :</strong> {subject}
+                        </p>
+                        <div
+                          style={{
+                            background: '#fff',
+                            border: '1px solid #929292',
+                            borderRadius: '4px',
+                            padding: '8px 12px',
+                            overflowY: 'auto',
+                            maxHeight: '320px',
+                            whiteSpace: 'pre-wrap',
+                            fontSize: '1rem',
+                            lineHeight: '1.5rem',
+                            color: '#161616',
+                          }}
+                        >
+                          {message}
+                        </div>
+                      </div>
                       <Input
                         label="Commentaire personnalisé (facultatif)"
                         hintText="Vous pouvez ajouter des informations ou demander des précisions au déclarant. Ce commentaire sera intégré au message automatique."

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -9,6 +9,7 @@ import type { useProcessingSteps } from '@/hooks/queries/processingSteps.hook';
 import { fetchAcknowledgmentMessage } from '@/lib/api/processingSteps';
 import { HttpError } from '@/lib/api/tanstackQuery';
 import styles from './CreateNoteDrawer.module.css';
+import drawerStyles from './SendAcknowledgmentDrawer.module.css';
 
 type StepType = NonNullable<ReturnType<typeof useProcessingSteps>['data']>['data'][number];
 
@@ -136,20 +137,8 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
       <Drawer.Root variant="nonModal" withCloseButton={false} open={isOpen} onOpenChange={handleOpenChange}>
         <Drawer.Portal>
           <Drawer.Panel style={{ width: 'min(90vw, 600px)', maxWidth: '100%' }} titleId={titleId}>
-            <div
-              style={{
-                height: '100vh',
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-            >
-              <div
-                style={{
-                  flex: 1,
-                  overflowY: 'auto',
-                  padding: '0 16px 88px 16px',
-                }}
-              >
+            <div className={drawerStyles.layout}>
+              <div className={drawerStyles.scrollArea}>
                 <div className="fr-container fr-mt-8w">
                   <div className={styles.topActions}>
                     <Button
@@ -177,46 +166,16 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                             déclarant.
                           </span>
                         </p>
-                        <div
-                          style={{
-                            background: '#fff',
-                            border: '1px solid #929292',
-                            borderRadius: '4px',
-                            padding: '8px 12px',
-                            minHeight: '2rem',
-                            overflowX: 'auto',
-                            whiteSpace: 'nowrap',
-                            fontSize: '1rem',
-                            lineHeight: '1.5rem',
-                            color: '#161616',
-                          }}
-                        >
-                          {declarantEmail}
-                        </div>
+                        <div className={drawerStyles.emailField}>{declarantEmail}</div>
                       </div>
                       <div className="fr-form-group fr-mb-2w">
                         <p className="fr-label fr-mb-1w">
                           Ce message est généré automatiquement et ne peut pas être modifié
                         </p>
-                        <p className="fr-text--sm fr-mb-1w" style={{ color: '#161616' }}>
+                        <p className={`fr-text--sm fr-mb-1w ${drawerStyles.subject}`}>
                           <strong>Objet :</strong> {subject}
                         </p>
-                        <div
-                          style={{
-                            background: '#fff',
-                            border: '1px solid #929292',
-                            borderRadius: '4px',
-                            padding: '8px 12px',
-                            overflowY: 'auto',
-                            maxHeight: '320px',
-                            whiteSpace: 'pre-wrap',
-                            fontSize: '1rem',
-                            lineHeight: '1.5rem',
-                            color: '#161616',
-                          }}
-                        >
-                          {message}
-                        </div>
+                        <div className={drawerStyles.messageField}>{message}</div>
                       </div>
                       <Input
                         label="Commentaire personnalisé (facultatif)"

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -317,7 +317,7 @@ const StepComponent = ({
             </div>
           </div>
         ) : (
-          <div className="fr-mb-2w">
+          <div className="fr-mb-1w">
             <div className="fr-grid-row fr-grid-row--middle">
               <div className="fr-col">
                 <h3 className="fr-h6 fr-mb-0">{getStepTitle(rest.type, statutId, nom)}</h3>

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -388,7 +388,7 @@ const StepComponent = ({
               )}
             </div>
             {notes[0]?.uploadedFiles && notes[0].uploadedFiles.filter((f) => !deletedFileIds.has(f.id)).length > 0 && (
-              <ul className="fr-mt-1w">
+              <ul className={`fr-mt-1w ${styles['cloture-files']}`}>
                 {notes[0].uploadedFiles
                   .filter((f) => !deletedFileIds.has(f.id))
                   .map((file: (typeof notes)[number]['uploadedFiles'][number]) => {

--- a/apps/frontend/src/components/requestId/processing/StepNote.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepNote.tsx
@@ -66,7 +66,7 @@ export const StepNote = ({
 
   return (
     <div className={styles['request-note']}>
-      <div className="fr-grid-row fr-grid-row--middle fr-mb-2w">
+      <div className="fr-grid-row fr-grid-row--middle fr-mb-1v">
         <p className={clsx('fr-col', styles['request-note__from'])}>
           Le
           <span>

--- a/apps/frontend/src/components/requestId/processing/StepNote.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepNote.tsx
@@ -67,7 +67,7 @@ export const StepNote = ({
   return (
     <div className={styles['request-note']}>
       <div className="fr-grid-row fr-grid-row--middle fr-mb-1v">
-        <p className={clsx('fr-col', styles['request-note__from'])}>
+        <p className={clsx('fr-col fr-mb-0', styles['request-note__from'])}>
           Le
           <span>
             {' '}

--- a/apps/frontend/src/lib/api/processingSteps.ts
+++ b/apps/frontend/src/lib/api/processingSteps.ts
@@ -94,12 +94,12 @@ export async function deleteProcessingStep(stepId: string) {
 
 export async function fetchAcknowledgmentMessage(
   stepId: string,
-): Promise<{ message: string; declarantEmail: string | null }> {
+): Promise<{ message: string; declarantEmail: string | null; subject: string }> {
   const res = await fetch(`/api/requete-etapes/${encodeURIComponent(stepId)}/acknowledgment-message`, {
     credentials: 'include',
   });
   await handleRequestErrors(res);
-  const json = (await res.json()) as { data: { message: string; declarantEmail: string | null } };
+  const json = (await res.json()) as { data: { message: string; declarantEmail: string | null; subject: string } };
   return json.data;
 }
 

--- a/apps/frontend/src/routes/_auth/_user/request.$requestId.module.css
+++ b/apps/frontend/src/routes/_auth/_user/request.$requestId.module.css
@@ -65,17 +65,22 @@
 }
 
 .request-step {
+  padding-left: 1.5rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--border-default-grey);
 }
 
 .request-step__add-note {
-  margin-left: 1rem;
+  margin-left: 0;
 }
 
 .request-notes-distplay {
-  margin: 0 1rem;
-  margin-bottom: 1rem;
+  margin: 0 0 1rem 0;
+}
+
+.cloture-files {
+  padding-left: 0;
+  list-style: none;
 }
 
 .request-notes {

--- a/apps/frontend/src/routes/_auth/_user/request.$requestId.module.css
+++ b/apps/frontend/src/routes/_auth/_user/request.$requestId.module.css
@@ -80,7 +80,7 @@
 
 .cloture-files {
   padding-left: 0;
-  list-style: none;
+  list-style-position: inside;
 }
 
 .request-notes {


### PR DESCRIPTION
- **fix: n'afficher que l'entité de l'agent dans le mail manuel d'accusé de réception**
- **fix: fix wording manual mail acknowledgment**
- **fix: fix subject  manual mail acknowledgment**
- **fix: n'afficher que l'entité de l'agent dans le preview du mail AR et exposer le sujet**
- **fix: verrouiller le badge de l'étape AR une fois passée en FAIT**
- **feat: remplacer les inputs readonly par des encarts et afficher l'objet du mail AR**
- **fix: rollback l'étape AR en A_FAIRE si l'envoi Tipimail échoue**
