### PR TITLE
fix: amélioration clic radio buttons prioritemenu 

### DIFF
--- a/apps/frontend/src/components/common/PrioriteMenu.tsx
+++ b/apps/frontend/src/components/common/PrioriteMenu.tsx
@@ -21,7 +21,7 @@ const prioriteClassMap: Record<string, string> = {
 };
 
 export function PrioriteMenu({ value, onChange, disabled, onOpen, onClose }: PrioriteMenuProps) {
-  const { isOpen, toggle, triggerRef, panelRef, onPanelBlur } = useDisclosureMenu({ onOpen, onClose });
+  const { isOpen, toggle, triggerRef, panelRef } = useDisclosureMenu({ onOpen, onClose });
   const [selectedValue, setSelectedValue] = useState(value);
   const menuId = useId();
 
@@ -50,7 +50,9 @@ export function PrioriteMenu({ value, onChange, disabled, onOpen, onClose }: Pri
         nativeInputProps: {
           value: badge.value,
           checked: selectedValue === badge.value,
-          onChange: () => handleSelect(badge.value),
+          onChange: () => {
+            handleSelect(badge.value);
+          },
         },
       })),
       {
@@ -94,12 +96,7 @@ export function PrioriteMenu({ value, onChange, disabled, onOpen, onClose }: Pri
         />
       </button>
       {isOpen && (
-        <div
-          id={menuId}
-          ref={panelRef}
-          className={prioriteStyles['priorite-filter__dropdown']}
-          onBlurCapture={onPanelBlur}
-        >
+        <div id={menuId} ref={panelRef} className={prioriteStyles['priorite-filter__dropdown']}>
           <RadioButtons legend="Choisir une priorité" name={`priorite-${menuId}`} options={options} />
         </div>
       )}

--- a/apps/frontend/src/hooks/useDisclosureMenu.ts
+++ b/apps/frontend/src/hooks/useDisclosureMenu.ts
@@ -34,18 +34,12 @@ export function useDisclosureMenu({ onOpen, onClose }: useDisclosureMenuOptions 
 
   useEffect(() => {
     if (!isOpen) return;
-
     const onMouseDown = (e: MouseEvent) => {
       const target = e.target as Node;
 
-      if (
-        panelRef.current &&
-        triggerRef.current &&
-        !panelRef.current.contains(target) &&
-        !triggerRef.current.contains(target)
-      ) {
-        close();
-      }
+      const isInside = panelRef.current?.contains(target) || triggerRef.current?.contains(target);
+
+      if (!isInside) close();
     };
 
     const onKeyDown = (e: KeyboardEvent) => {


### PR DESCRIPTION
-retire la fermeture du panneau après sélection d'un choix
- Suppression de onBlurCapture car il fermait le menu lors des changements de focus internes (ex : clic sur une radio), provoquant une fermeture involontaire et un effet de “freeze” côté souris.
- La fermeture du menu est désormais gérée par le clic en dehors du panneau et la touche Escape, pour un comportement plus fiable et prévisible / similaire au filtre des départements
