### PR TITLE
fix/sirena-343-fix

### DIFF
--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -267,19 +267,22 @@ type EntiteForMessage = {
   entiteMereId: string | null;
 };
 
-const LOGO_URL = 'https://sirena-sante.social.gouv.fr/republique_francaise_rvb.png';
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
 
 function buildAcknowledgmentMessageHtml(text: string): string {
+  const logoUrl = `${envVars.FRONTEND_URI}/republique_francaise_rvb.png`;
   const lines = text
     .split('\n')
-    .map((line) => (line.trim() === '' ? '<br>' : `<p style="margin:0 0 4px 0">${line}</p>`))
+    .map((line) => (line.trim() === '' ? '<br>' : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`))
     .join('\n');
   return `<!DOCTYPE html>
 <html lang="fr">
 <body style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:600px;margin:0 auto;padding:20px">
   ${lines}
   <br>
-  <img src="${LOGO_URL}" alt="République Française" style="height:80px;margin-top:24px">
+  <img src="${escapeHtml(logoUrl)}" alt="République Française" style="height:80px;margin-top:24px">
 </body>
 </html>`;
 }

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -276,7 +276,9 @@ function buildAcknowledgmentMessageHtml(text: string): string {
   const lines = text
     .split('\n')
     .map((line) =>
-      line.trim() === '' ? '<div style="margin:0 0 12px 0"></div>' : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`,
+      line.trim() === ''
+        ? '<div style="margin:0 0 12px 0"></div>'
+        : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`,
     )
     .join('\n');
   return `<!DOCTYPE html>

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -276,7 +276,7 @@ function buildAcknowledgmentMessageHtml(text: string): string {
   const lines = text
     .split('\n')
     .map((line) =>
-      line.trim() === '' ? '<p style="margin:0 0 12px 0"></p>' : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`,
+      line.trim() === '' ? '<div style="margin:0 0 12px 0"></div>' : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`,
     )
     .join('\n');
   return `<!DOCTYPE html>

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -107,6 +107,7 @@ async function attachEmailPdfToStep(
     subject?: string;
     substitutions?: Record<string, unknown>;
   },
+  authorId?: string | null,
 ): Promise<void> {
   const logger = getLoggerStore();
 
@@ -216,7 +217,7 @@ async function attachEmailPdfToStep(
       const note = await prisma.requeteEtapeNote.create({
         data: {
           texte: `Email d'accusé de réception envoyé le ${emailInfo.sentDate.toLocaleString('fr-FR')}`,
-          authorId: null,
+          authorId: authorId ?? null,
           requeteEtapeId: etape.id,
           uploadedFiles: {
             connect: [{ id: uploadedFile.id }],
@@ -412,12 +413,13 @@ export async function sendManualAcknowledgmentEmail({
         text: message,
       });
 
-      await attachEmailPdfToStep(requeteId, entiteId, emailPdf, {
-        from,
-        to: declarantEmail,
-        sentDate,
-        subject: ACKNOWLEDGMENT_EMAIL_SUBJECT,
-      });
+      await attachEmailPdfToStep(
+        requeteId,
+        entiteId,
+        emailPdf,
+        { from, to: declarantEmail, sentDate, subject: ACKNOWLEDGMENT_EMAIL_SUBJECT },
+        userId,
+      );
     } catch (pdfError) {
       logger.error(
         { requeteId, entiteId, error: pdfError },

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -272,12 +272,14 @@ type EntiteForMessage = {
 export function buildAcknowledgmentMessageText(
   requeteId: string,
   entites: EntiteForMessage[],
+  declarant: { nom: string; prenom: string },
   comment?: string,
 ): string {
   const entiteAdmin = formatEntiteAdminString(entites);
   const entiteComplete = formatEntiteCompleteString(entites);
+  const declarantName = `${declarant.nom.toUpperCase()} ${declarant.prenom}`;
   return [
-    `Bonjour,`,
+    `Bonjour ${declarantName},`,
     `Votre dossier a bien été reçu sous le numéro ${requeteId}.`,
     `Merci d'avoir pris le temps de partager ces informations.`,
     `Il est désormais suivi par ${entiteAdmin}.`,
@@ -350,7 +352,9 @@ export async function sendManualAcknowledgmentEmail({
       logger.error({ requeteId, entiteId }, 'Declarant has no email for manual acknowledgment');
       throw new Error("Le déclarant n'a pas d'adresse e-mail renseignée.");
     }
-    const message = buildAcknowledgmentMessageText(requeteId, entites, comment);
+    const declarantIdentite = declarantResult?.declarant?.identite;
+    const declarant = { nom: declarantIdentite?.nom ?? '', prenom: declarantIdentite?.prenom ?? '' };
+    const message = buildAcknowledgmentMessageText(requeteId, entites, declarant, comment);
     const fromAddress = envVars.TIPIMAIL_FROM_ADDRESS;
     const fromPersonalName = envVars.TIPIMAIL_FROM_PERSONAL_NAME;
     const from = { address: fromAddress, personalName: fromPersonalName };

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -266,6 +266,23 @@ type EntiteForMessage = {
   entiteMereId: string | null;
 };
 
+const LOGO_URL = 'https://sirena-sante.social.gouv.fr/republique_francaise_rvb.png';
+
+function buildAcknowledgmentMessageHtml(text: string): string {
+  const lines = text
+    .split('\n')
+    .map((line) => (line.trim() === '' ? '<br>' : `<p style="margin:0 0 4px 0">${line}</p>`))
+    .join('\n');
+  return `<!DOCTYPE html>
+<html lang="fr">
+<body style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:600px;margin:0 auto;padding:20px">
+  ${lines}
+  <br>
+  <img src="${LOGO_URL}" alt="République Française" style="height:80px;margin-top:24px">
+</body>
+</html>`;
+}
+
 /**
  * Builds the plain-text acknowledgment message for manual acknowledgment sending
  */
@@ -364,6 +381,7 @@ export async function sendManualAcknowledgmentEmail({
       to: declarantEmail,
       subject: ACKNOWLEDGMENT_EMAIL_SUBJECT,
       text: message,
+      html: buildAcknowledgmentMessageHtml(message),
     });
 
     logger.info({ requeteId, entiteId, declarantEmail }, 'Manual acknowledgment email sent successfully');

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -275,13 +275,14 @@ function buildAcknowledgmentMessageHtml(text: string): string {
   const logoUrl = `${envVars.FRONTEND_URI}/republique_francaise_rvb.png`;
   const lines = text
     .split('\n')
-    .map((line) => (line.trim() === '' ? '<br>' : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`))
+    .map((line) =>
+      line.trim() === '' ? '<p style="margin:0 0 12px 0"></p>' : `<p style="margin:0 0 4px 0">${escapeHtml(line)}</p>`,
+    )
     .join('\n');
   return `<!DOCTYPE html>
 <html lang="fr">
 <body style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:600px;margin:0 auto;padding:20px">
   ${lines}
-  <br>
   <img src="${escapeHtml(logoUrl)}" alt="République Française" style="height:80px;margin-top:24px">
 </body>
 </html>`;

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
@@ -454,8 +454,10 @@ const app = factoryWithLogs
       getRequeteEntiteById(requeteEtape.requeteId, topEntiteId),
     ]);
     const entites = entite ? [entite] : [];
-    const message = buildAcknowledgmentMessageText(requeteEtape.requeteId, entites);
-    const declarantEmail = requete?.requete?.declarant?.identite?.email ?? null;
+    const declarantIdentite = requete?.requete?.declarant?.identite;
+    const declarant = { nom: declarantIdentite?.nom ?? '', prenom: declarantIdentite?.prenom ?? '' };
+    const message = buildAcknowledgmentMessageText(requeteEtape.requeteId, entites, declarant);
+    const declarantEmail = declarantIdentite?.email ?? null;
 
     logger.info({ requeteEtapeId: id }, 'Acknowledgment message preview fetched');
 

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -82,14 +82,11 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                 step.createdBy === null &&
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
-              const isAcknowledgmentMailSent =
-                step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&
-                step.notes.some((note) => note.uploadedFiles.length > 0);
               const isDisabled =
                 index === data.data.length - 1 ||
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ||
                 isAutomaticallyUpdated ||
-                isAcknowledgmentMailSent;
+                (step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT);
               const isAcknowledgmentSendable =
                 isManualRequest &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -82,11 +82,14 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                 step.createdBy === null &&
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
+              const isAcknowledgmentMailSent =
+                step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&
+                step.notes.some((note) => note.author === null && note.uploadedFiles.length > 0);
               const isDisabled =
                 index === data.data.length - 1 ||
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ||
                 isAutomaticallyUpdated ||
-                (step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT);
+                isAcknowledgmentMailSent;
               const isAcknowledgmentSendable =
                 isManualRequest &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -84,7 +84,7 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
               const isAcknowledgmentMailSent =
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&
-                step.notes.some((note) => note.author === null && note.uploadedFiles.length > 0);
+                step.notes.some((note) => note.uploadedFiles.length > 0);
               const isDisabled =
                 index === data.data.length - 1 ||
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ||

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.module.css
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.module.css
@@ -19,11 +19,6 @@
   margin-inline-start: 0 !important;
 }
 
-.dlInline dt,
-.dlInline dd {
-  display: inline;
-}
-
 .emailField {
   background: #fff;
   border: 1px solid #929292;
@@ -34,10 +29,6 @@
   white-space: nowrap;
   font-size: 1rem;
   line-height: 1.5rem;
-  color: #161616;
-}
-
-.subject {
   color: #161616;
 }
 

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -44,9 +44,11 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
     const titleRef = useRef<HTMLHeadingElement>(null);
 
     useEffect(() => {
-      if (isOpen) {
+      if (!isOpen) return;
+      const timeout = setTimeout(() => {
         titleRef.current?.focus();
-      }
+      }, 0);
+      return () => clearTimeout(timeout);
     }, [isOpen]);
 
     const handleReset = () => {
@@ -180,7 +182,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                         <p className="fr-label fr-mb-1w">
                           Ce message est généré automatiquement et ne peut pas être modifié
                         </p>
-                        <div className={drawerStyles.messageField}>{message}</div>
+                        <p className={drawerStyles.messageField}>{message}</p>
                       </div>
                       <Input
                         label="Commentaire personnalisé (facultatif)"

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -30,7 +30,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
     const [isOpen, setIsOpen] = useState(false);
     const [step, setStep] = useState<StepType | null>(null);
     const [declarantEmail, setDeclarantEmail] = useState('');
-    const [subject, setSubject] = useState('');
+
     const [message, setMessage] = useState('');
     const [comment, setComment] = useState('');
     const [isLoadingMessage, setIsLoadingMessage] = useState(false);
@@ -52,7 +52,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
     const handleReset = () => {
       setStep(null);
       setDeclarantEmail('');
-      setSubject('');
+
       setMessage('');
       setComment('');
       setIsLoadingMessage(false);
@@ -67,7 +67,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
       try {
         const data = await fetchAcknowledgmentMessage(s.id);
         setDeclarantEmail(data.declarantEmail ?? '');
-        setSubject(data.subject);
+
         setMessage(data.message);
       } catch {
         toastManager.add({
@@ -162,24 +162,23 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                         <dl className={drawerStyles.dl}>
                           <dt className="fr-label fr-mb-1w">
                             Adresse électronique du déclarant
-                            <span className="fr-hint-text">
-                              Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les
-                              informations déclarant.
-                            </span>
+                            {declarantEmail && (
+                              <span className="fr-hint-text">
+                                Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les
+                                informations déclarant.
+                              </span>
+                            )}
                           </dt>
-                          <dd className={drawerStyles.emailField}>{declarantEmail}</dd>
+                          <dd className={declarantEmail ? drawerStyles.emailField : 'fr-text--sm fr-error-text'}>
+                            {declarantEmail ||
+                              'L\'adresse électronique du déclarant n\'est pas renseignée. Veuillez la renseigner dans la section "Déclarant".'}
+                          </dd>
                         </dl>
                       </div>
                       <div className="fr-form-group fr-mb-2w">
                         <p className="fr-label fr-mb-1w">
                           Ce message est généré automatiquement et ne peut pas être modifié
                         </p>
-                        <dl className={`${drawerStyles.dl} ${drawerStyles.dlInline}`}>
-                          <dt className={`fr-text--sm ${drawerStyles.subject}`}>
-                            <span className="fr-text--bold">Objet :</span>
-                          </dt>
-                          <dd className={`fr-text--sm fr-mb-1w ${drawerStyles.subject}`}>{subject}</dd>
-                        </dl>
                         <div className={drawerStyles.messageField}>{message}</div>
                       </div>
                       <Input

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -164,8 +164,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                             <dt className="fr-label fr-mb-1w">
                               Adresse électronique du déclarant
                               <span className="fr-hint-text">
-                                Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les
-                                informations déclarant.
+                                Pour modifier cette adresse, rendez-vous dans la section Déclarant.
                               </span>
                             </dt>
                             <dd className={drawerStyles.emailField}>{declarantEmail}</dd>

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -159,21 +159,23 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                   ) : (
                     <form>
                       <div className="fr-form-group fr-mb-2w">
-                        <dl className={drawerStyles.dl}>
-                          <dt className="fr-label fr-mb-1w">
-                            Adresse électronique du déclarant
-                            {declarantEmail && (
+                        {declarantEmail ? (
+                          <dl className={drawerStyles.dl}>
+                            <dt className="fr-label fr-mb-1w">
+                              Adresse électronique du déclarant
                               <span className="fr-hint-text">
                                 Ce champ est en lecture seule. Vous pouvez modifier l'adresse e-mail depuis les
                                 informations déclarant.
                               </span>
-                            )}
-                          </dt>
-                          <dd className={declarantEmail ? drawerStyles.emailField : 'fr-text--sm fr-error-text'}>
-                            {declarantEmail ||
-                              'L\'adresse électronique du déclarant n\'est pas renseignée. Veuillez la renseigner dans la section "Déclarant".'}
-                          </dd>
-                        </dl>
+                            </dt>
+                            <dd className={drawerStyles.emailField}>{declarantEmail}</dd>
+                          </dl>
+                        ) : (
+                          <p className="fr-text--sm fr-error-text">
+                            L&apos;adresse électronique du déclarant n&apos;est pas renseignée. Veuillez la renseigner
+                            dans la section &quot;Déclarant&quot;.
+                          </p>
+                        )}
                       </div>
                       <div className="fr-form-group fr-mb-2w">
                         <p className="fr-label fr-mb-1w">

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -120,9 +120,19 @@ const getStepSubtitle = (
     );
   }
   if (type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT) {
-    return statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT
-      ? `Envoyé automatiquement le ${formatDate(updatedAt)}`
-      : `Ajouté automatiquement le ${formatDate(createdAt)}`;
+    if (statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT) {
+      const sendNote = notes.find((note) => note.uploadedFiles.length > 0);
+      const isManualRequest = !!requete?.createdBy;
+      if (isManualRequest && sendNote?.author) {
+        return (
+          <>
+            Envoyé le {formatDate(updatedAt)} par {formatAgent(sendNote.author)}
+          </>
+        );
+      }
+      return `Envoyé automatiquement le ${formatDate(updatedAt)}`;
+    }
+    return `Ajouté automatiquement le ${formatDate(createdAt)}`;
   }
   return formatStepCreationInfo(createdBy, createdAt);
 };


### PR DESCRIPTION
## Changements

- Ajout du nom et prénom du déclarant dans le mail AR (`Bonjour NOM Prenom,`)
- Logo République Française en bas du mail AR manuel
- Affichage de l'expéditeur dans le sous-titre de l'étape AR (`Envoyé le XX/XX par Prénom NOM`)
- Drawer d'envoi AR : retrait de l'objet, message d'erreur si email déclarant vide, hint reformulé
- Fix focus automatique à l'ouverture du drawer
- Message dans balise `<p>` au lieu de `<div>`
- Le statut AR reste modifiable tant que le mail n'a pas été envoyé via le drawer
