### PR TITLE
feat: badge +90 jours sur les requêtes ouvertes anciennes

### DIFF
--- a/apps/frontend/src/components/common/tables/requetesEntites.css
+++ b/apps/frontend/src/components/common/tables/requetesEntites.css
@@ -30,3 +30,10 @@
 .requetesEntitesTable .fr-cell:has(.requetesEntitesTable__misEnCause-cell) {
   min-width: var(--table-column-min-width);
 }
+
+.requetesEntitesTable__reception-date-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/apps/frontend/src/components/common/tables/requetesEntites.tsx
+++ b/apps/frontend/src/components/common/tables/requetesEntites.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox';
 import { Pagination } from '@codegouvfr/react-dsfr/Pagination';
 import { SearchBar } from '@codegouvfr/react-dsfr/SearchBar';
 import type { RequetePrioriteType, RequeteStatutType } from '@sirena/common/constants';
-import { entiteTypes } from '@sirena/common/constants';
+import { entiteTypes, REQUETE_STATUT_TYPES } from '@sirena/common/constants';
 import { type Cells, type Column, DataTable, type OnSortChangeParams } from '@sirena/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useSearch } from '@tanstack/react-router';
@@ -16,6 +16,7 @@ import { useRequetesListSSE } from '@/hooks/useRequetesListSSE';
 import { RequetePrioriteTag, RequeteStatutTag } from '../RequeteStatutTag';
 import { renderAffectationCell, renderMisEnCauseCell, renderMotifsCell } from './requetesEntites.cells';
 import './requetesEntites.css';
+import Badge from '@codegouvfr/react-dsfr/Badge';
 
 type RequeteEntiteRow = NonNullable<Awaited<ReturnType<typeof useRequetesEntite>>['data']>['data'][number] & {
   id: string;
@@ -293,15 +294,21 @@ export function RequetesEntite() {
 
   const cells: Cells<RequeteEntiteRow> = {
     'requete.id': (row) => <span className="one-line">{row.requete.id}</span>,
-    'requete.receptionDate': (row) => (
-      <div>
-        {new Date(row.requete.createdAt).toLocaleDateString('fr-FR', {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-        })}
-      </div>
-    ),
+    'requete.receptionDate': (row) => {
+      const createdAt = new Date(row.requete.createdAt);
+      const isOpen = row.statutId === REQUETE_STATUT_TYPES.NOUVEAU || row.statutId === REQUETE_STATUT_TYPES.EN_COURS;
+      const isOver90Days = isOpen && Date.now() - createdAt.getTime() > 90 * 24 * 60 * 60 * 1000;
+      return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          {createdAt.toLocaleDateString('fr-FR', { year: 'numeric', month: '2-digit', day: '2-digit' })}
+          {isOver90Days && (
+            <Badge severity="warning" noIcon small>
+              +90 jours
+            </Badge>
+          )}
+        </div>
+      );
+    },
     'custom:statut': (row) => {
       return (
         <div className="requetesEntitesTable__statut-cell">

--- a/apps/frontend/src/components/common/tables/requetesEntites.tsx
+++ b/apps/frontend/src/components/common/tables/requetesEntites.tsx
@@ -299,11 +299,11 @@ export function RequetesEntite() {
       const isOpen = row.statutId === REQUETE_STATUT_TYPES.NOUVEAU || row.statutId === REQUETE_STATUT_TYPES.EN_COURS;
       const isOver90Days = isOpen && Date.now() - createdAt.getTime() > 90 * 24 * 60 * 60 * 1000;
       return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <div className="requetesEntitesTable__reception-date-cell">
           {createdAt.toLocaleDateString('fr-FR', { year: 'numeric', month: '2-digit', day: '2-digit' })}
           {isOver90Days && (
             <Badge severity="warning" noIcon small>
-              +90 jours
+              <span className="fr-sr-only">Dossier reçu depuis</span>+90 jours
             </Badge>
           )}
         </div>


### PR DESCRIPTION
Affiche un badge warning «+90 jours» dans la colonne «Réception» lorsqu'une requête ouverte (statut Nouveau ou En cours) a été créée il y a plus de 90 jours.