### PR TITLE
fix: stop file status polling after 2 minutes when worker is unavailable

### DIFF
--- a/apps/frontend/src/components/common/FileDownloadLink.tsx
+++ b/apps/frontend/src/components/common/FileDownloadLink.tsx
@@ -298,7 +298,7 @@ export const FileDownloadLink = ({
 
   const { isConnected: sseConnected } = useFileStatusSSE({
     fileId: fileId || '',
-    enabled: !!fileId && !pollingDisabledRef.current && !isProcessingComplete(fileStatus),
+    enabled: !import.meta.env.DEV && !!fileId && !pollingDisabledRef.current && !isProcessingComplete(fileStatus),
     onStatusChange: handleSSEStatusChange,
   });
 
@@ -325,6 +325,7 @@ export const FileDownloadLink = ({
   // Fallback to polling if SSE is not connected
   useEffect(() => {
     if (!fileId || pollingDisabledRef.current || isProcessingComplete(fileStatus)) return;
+    if (import.meta.env.DEV) return;
 
     // If SSE is connected, don't poll
     if (sseConnected) return;

--- a/apps/frontend/src/components/common/FileDownloadLink.tsx
+++ b/apps/frontend/src/components/common/FileDownloadLink.tsx
@@ -298,7 +298,7 @@ export const FileDownloadLink = ({
 
   const { isConnected: sseConnected } = useFileStatusSSE({
     fileId: fileId || '',
-    enabled: !import.meta.env.DEV && !!fileId && !pollingDisabledRef.current && !isProcessingComplete(fileStatus),
+    enabled: !!fileId && !pollingDisabledRef.current && !isProcessingComplete(fileStatus),
     onStatusChange: handleSSEStatusChange,
   });
 
@@ -325,7 +325,6 @@ export const FileDownloadLink = ({
   // Fallback to polling if SSE is not connected
   useEffect(() => {
     if (!fileId || pollingDisabledRef.current || isProcessingComplete(fileStatus)) return;
-    if (import.meta.env.DEV) return;
 
     // If SSE is connected, don't poll
     if (sseConnected) return;

--- a/apps/frontend/src/components/common/FileDownloadLink.tsx
+++ b/apps/frontend/src/components/common/FileDownloadLink.tsx
@@ -211,6 +211,7 @@ const getWarningMessage = (
 };
 
 const POLL_INTERVAL = 3000;
+const MAX_POLL_DURATION_MS = 2 * 60 * 1000; // stop polling after 2 minutes
 
 const FILE_TAG_STYLE = {
   valid: {
@@ -291,6 +292,7 @@ export const FileDownloadLink = ({
   const initialPollDoneRef = useRef(false);
   const pollingDisabledRef = useRef(false);
   const sseDisconnectedRef = useRef(false);
+  const pollStartedAtRef = useRef<number | null>(null);
 
   const handleSSEStatusChange = useCallback((status: FileProcessingStatus) => {
     setFileStatus(status);
@@ -311,6 +313,12 @@ export const FileDownloadLink = ({
 
   const pollStatus = useCallback(async () => {
     if (!fileId || pollingDisabledRef.current) return;
+
+    if (pollStartedAtRef.current !== null && Date.now() - pollStartedAtRef.current > MAX_POLL_DURATION_MS) {
+      pollingDisabledRef.current = true;
+      return;
+    }
+
     try {
       const status = await getFileProcessingStatus(fileId);
       setFileStatus(status);
@@ -328,6 +336,10 @@ export const FileDownloadLink = ({
 
     // If SSE is connected, don't poll
     if (sseConnected) return;
+
+    if (pollStartedAtRef.current === null) {
+      pollStartedAtRef.current = Date.now();
+    }
 
     // Poll immediately on first run if no initial status was provided
     if (!initialPollDoneRef.current && !initialStatus) {

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -310,8 +310,13 @@ const StepComponent = ({
                 </ButtonLink>
               </div>
               <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-                <div className="fr-btns-group fr-btns-group--inline">
-                  <Button priority="secondary" size="small" onClick={() => handleEditButton(false)}>
+                <div className="fr-grid-row">
+                  <Button
+                    className="fr-mr-1w"
+                    priority="secondary"
+                    size="small"
+                    onClick={() => handleEditButton(false)}
+                  >
                     Annuler
                   </Button>
                   <Button

--- a/apps/frontend/src/components/requestId/processing/createStep.tsx
+++ b/apps/frontend/src/components/requestId/processing/createStep.tsx
@@ -59,8 +59,14 @@ const CreateStepComponent = ({ requestId, isAddingStep, setIsAddingStep }: Creat
               stateRelatedMessage={stepNameError}
             />
           </div>
-          <div className="fr-btns-group fr-btns-group--inline fr-grid-row--right">
-            <Button priority="secondary" size="small" onClick={handleCancel} disabled={addStepMutation.isPending}>
+          <div className="fr-grid-row fr-grid-row--right">
+            <Button
+              className="fr-mr-1w"
+              priority="secondary"
+              size="small"
+              onClick={handleCancel}
+              disabled={addStepMutation.isPending}
+            >
               Annuler
             </Button>
             <Button priority="primary" size="small" onClick={handleAddStep} disabled={addStepMutation.isPending}>


### PR DESCRIPTION
## Summary

When the file processing worker is down or unreachable, uploaded files stay in `PENDING`/`SCANNING` state indefinitely. This caused the frontend to poll `/api/uploaded-files/:id/status` every 3 seconds forever, flooding the browser network tab and making the app sluggish.

## Fix

Polling now stops automatically after **2 minutes** via a `pollStartedAtRef` timestamp checked on each poll attempt. In normal conditions (worker running), files reach a final state (`CLEAN`, `INFECTED`, `ERROR`) well within that window and polling stops naturally.

## Also includes

- Step action buttons size aligned with standalone buttons (`Ajouter une étape`, `Clôturer`)