### PR TITLE
feat: disable priority editing and auto-reset it on closure

### DIFF
--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -1664,6 +1664,13 @@ export const closeRequeteForEntite = async (
 
     await updateStatusRequete(requeteId, entiteId, REQUETE_STATUT_TYPES.CLOTUREE, tx);
 
+    if (requeteEntite.prioriteId) {
+      await tx.requeteEntite.update({
+        where: { requeteId_entiteId: { requeteId, entiteId } },
+        data: { prioriteId: null },
+      });
+    }
+
     return {
       etapeId: etape.id,
       closedAt: etape.createdAt.toISOString(),

--- a/apps/frontend/src/components/requestId/requestInfos.tsx
+++ b/apps/frontend/src/components/requestId/requestInfos.tsx
@@ -69,7 +69,9 @@ export const RequestInfos = ({
                     <PrioriteMenu
                       value={prioriteId || null}
                       onChange={handlePrioriteChange}
-                      disabled={!requestId || updatePrioriteMutation.isPending}
+                      disabled={
+                        !requestId || updatePrioriteMutation.isPending || statutId === REQUETE_STATUT_TYPES.CLOTUREE
+                      }
                     />
 
                     {showPriseEnCompteToggle && (


### PR DESCRIPTION
## Summary

- Priority menu is disabled when a request is closed
- Priority is automatically reset to `null` when closing a request (backend, inside the closure transaction)