### PR TITLE
fix: improve read-only fields display in TraitementDesFaits

### DIFF
--- a/apps/frontend/src/components/situation/TraitementDesFaits.module.css
+++ b/apps/frontend/src/components/situation/TraitementDesFaits.module.css
@@ -57,6 +57,10 @@
   border-radius: 4px 4px 0 0;
   border: 1px solid var(--border-default-grey, #ddd);
   min-height: 2.5rem;
+  background: transparent;
+  font: inherit;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .container {

--- a/apps/frontend/src/components/situation/TraitementDesFaits.module.css
+++ b/apps/frontend/src/components/situation/TraitementDesFaits.module.css
@@ -46,6 +46,19 @@
   white-space: nowrap;
 }
 
+.readOnlyValue {
+  display: flex;
+  padding: 8px 16px;
+  align-items: center;
+  align-content: center;
+  gap: 6px;
+  align-self: stretch;
+  flex-wrap: wrap;
+  border-radius: 4px 4px 0 0;
+  border: 1px solid var(--border-default-grey, #ddd);
+  min-height: 2.5rem;
+}
+
 .container {
   border: 2px solid var(--border-action-high-blue-france);
   border-radius: 0.25rem;

--- a/apps/frontend/src/components/situation/TraitementDesFaits.tsx
+++ b/apps/frontend/src/components/situation/TraitementDesFaits.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@codegouvfr/react-dsfr/Button';
-import { Input } from '@codegouvfr/react-dsfr/Input';
 import { Select } from '@codegouvfr/react-dsfr/Select';
 import { SelectWithChildren } from '@sirena/ui';
 import { useEffect, useId, useRef, useState } from 'react';
@@ -74,14 +73,10 @@ function TraitementDesFaitsRowComponent({
         <div className={styles.entiteWrapper}>
           <div className={styles.entiteField}>
             {isEntiteReadOnly ? (
-              <Input
-                label={'Entité administrative (obligatoire) '}
-                nativeInputProps={{
-                  value: entiteLabel,
-                  readOnly: true,
-                  'aria-readonly': true,
-                }}
-              />
+              <div className="fr-input-group">
+                <p className="fr-label">Entité administrative (obligatoire)</p>
+                <div className={styles.readOnlyValue}>{entiteLabel}</div>
+              </div>
             ) : (
               <Select
                 label={'Entité administrative (obligatoire) '}
@@ -115,21 +110,18 @@ function TraitementDesFaitsRowComponent({
       </div>
 
       {/* Direction / service */}
-      {row.entiteId && (
+      {row.entiteId && (!disabled || (row.directionServiceIds && row.directionServiceIds.length > 0)) && (
         <div className="fr-col-12 fr-col-md-6" style={alignSelectStyle}>
           {disabled ? (
-            <Input
-              label="Direction ou Service"
-              nativeInputProps={{
-                value:
-                  row.directionServiceIds
-                    ?.map((id) => directionsServices.find((ds) => ds.id === id)?.nomComplet)
-                    .filter(Boolean)
-                    .join(', ') || '',
-                readOnly: true,
-                'aria-readonly': true,
-              }}
-            />
+            <div className="fr-input-group">
+              <p className="fr-label">Direction ou Service</p>
+              <div className={styles.readOnlyValue}>
+                {row.directionServiceIds
+                  ?.map((id) => directionsServices.find((ds) => ds.id === id)?.nomComplet)
+                  .filter(Boolean)
+                  .join(', ') || ''}
+              </div>
+            </div>
           ) : (
             <SelectWithChildren
               value={row.directionServiceIds || []}
@@ -385,19 +377,6 @@ function TraitementDesFaitsSection({
               </div>
             );
           })}
-          <p className="fr-text--md fr-mb-2w">
-            Ajoutez une autre entité si le traitement de la situation concerne plusieurs entités.
-          </p>
-
-          <Button
-            iconId="fr-icon-add-line"
-            iconPosition="right"
-            priority="secondary"
-            onClick={handleAddRow}
-            disabled={disabled}
-          >
-            Ajouter une autre entité
-          </Button>
           <hr className="fr-mt-4w" />
           {rows.readOnlyRows.length > 0 && (
             <p className="fr-text--md fr-mb-2w fr-text--bold">Autres entités affectées au traitement</p>
@@ -412,6 +391,19 @@ function TraitementDesFaitsSection({
               disabled
             />
           ))}
+          <p className="fr-text--md fr-mb-2w">
+            Ajoutez une autre entité si le traitement de la situation concerne plusieurs entités.
+          </p>
+
+          <Button
+            iconId="fr-icon-add-line"
+            iconPosition="right"
+            priority="secondary"
+            onClick={handleAddRow}
+            disabled={disabled}
+          >
+            Ajouter une autre entité
+          </Button>
         </div>
       </fieldset>
     </div>

--- a/apps/frontend/src/components/situation/TraitementDesFaits.tsx
+++ b/apps/frontend/src/components/situation/TraitementDesFaits.tsx
@@ -74,8 +74,10 @@ function TraitementDesFaitsRowComponent({
           <div className={styles.entiteField}>
             {isEntiteReadOnly ? (
               <div className="fr-input-group">
-                <p className="fr-label">Entité administrative (obligatoire)</p>
-                <div className={styles.readOnlyValue}>{entiteLabel}</div>
+                <label className="fr-label" htmlFor={`entite-readonly-${row.id}`}>
+                  Entité administrative (obligatoire)
+                </label>
+                <input id={`entite-readonly-${row.id}`} className={styles.readOnlyValue} value={entiteLabel} readOnly />
               </div>
             ) : (
               <Select
@@ -114,13 +116,20 @@ function TraitementDesFaitsRowComponent({
         <div className="fr-col-12 fr-col-md-6" style={alignSelectStyle}>
           {disabled ? (
             <div className="fr-input-group">
-              <p className="fr-label">Direction ou Service</p>
-              <div className={styles.readOnlyValue}>
-                {row.directionServiceIds
-                  ?.map((id) => directionsServices.find((ds) => ds.id === id)?.nomComplet)
-                  .filter(Boolean)
-                  .join(', ') || ''}
-              </div>
+              <label className="fr-label" htmlFor={`direction-readonly-${row.id}`}>
+                Direction ou Service
+              </label>
+              <input
+                id={`direction-readonly-${row.id}`}
+                className={styles.readOnlyValue}
+                value={
+                  row.directionServiceIds
+                    ?.map((id) => directionsServices.find((ds) => ds.id === id)?.nomComplet)
+                    .filter(Boolean)
+                    .join(', ') || ''
+                }
+                readOnly
+              />
             </div>
           ) : (
             <SelectWithChildren
@@ -377,7 +386,7 @@ function TraitementDesFaitsSection({
               </div>
             );
           })}
-          <hr className="fr-mt-4w" />
+          <div className="fr-mt-4w" />
           {rows.readOnlyRows.length > 0 && (
             <p className="fr-text--md fr-mb-2w fr-text--bold">Autres entités affectées au traitement</p>
           )}


### PR DESCRIPTION
## Summary

- Read-only entity/direction fields now render as styled text boxes (light grey border) instead of disabled inputs that look clickable
- "Direction ou Service" is hidden when empty in the read-only rows section
- "Ajouter une autre entité" button and hint text moved to the bottom, after the read-only rows