### PR TITLE
fix: Migration pour les requêtes téléphoniques mal attribuées

### DIFF
--- a/packages/db/prisma/migrations/20260518000000_fix_reception_type_for_telephonique_requetes/migration.sql
+++ b/packages/db/prisma/migrations/20260518000000_fix_reception_type_for_telephonique_requetes/migration.sql
@@ -1,0 +1,9 @@
+-- Fix requetes created from the phone platform that were incorrectly
+-- attributed the 'TELEPHONE' reception type instead of 'PLATEFORME'.
+-- Telephone-platform requetes are identified by their functional id pattern
+-- 'YYYY-MM-RT<number>' (see generateRequeteId / SOURCE_PREFIX.TELEPHONIQUE).
+-- ---------------------------------------------------------------------------
+UPDATE "Requete"
+SET "receptionTypeId" = 'PLATEFORME'
+WHERE "receptionTypeId" = 'TELEPHONE'
+  AND "id" ~ '^[0-9]{4}-[0-9]{2}-RT[0-9]+$';


### PR DESCRIPTION
```
-- Test fixtures ; run locally to verify the UPDATE below targets only the intended rows.
--
-- INSERT INTO "Requete" ("id", "receptionTypeId", "updatedAt") VALUES
--   ('2026-05-RT9001', 'TELEPHONE',  NOW()), -- should switch to PLATEFORME
--   ('2026-05-RT9002', 'TELEPHONE',  NOW()), -- should switch to PLATEFORME
--   ('2026-05-RT9003', 'PLATEFORME', NOW()), -- already correct, must stay PLATEFORME
--   ('2026-05-RS9004', 'TELEPHONE',  NOW()), -- SIRENA source, must stay TELEPHONE
--   ('2026-05-RF9005', 'TELEPHONE',  NOW()), -- FORMULAIRE source, must stay TELEPHONE
--   ('2026-05-RT9006', 'EMAIL',      NOW()), -- non-TELEPHONE reception, must stay EMAIL
--   ('legacy-RT-id',   'TELEPHONE',  NOW()); -- unrelated id format, must stay TELEPHONE
--
-- Expected after running the migration:
  -- SELECT id, "receptionTypeId" FROM "Requete" WHERE id LIKE '%9%' OR id = 'legacy-RT-id';
  -- 2026-05-RT9001 | PLATEFORME
  -- 2026-05-RT9002 | PLATEFORME
  -- 2026-05-RT9003 | PLATEFORME
  -- 2026-05-RS9004 | TELEPHONE
  -- 2026-05-RF9005 | TELEPHONE
  -- 2026-05-RT9006 | EMAIL
  -- legacy-RT-id   | TELEPHONE
--
-- Cleanup after manual verification:
-- DELETE FROM "Requete"
--  WHERE id IN ('2026-05-RT9001','2026-05-RT9002','2026-05-RT9003',
--               '2026-05-RS9004','2026-05-RF9005','2026-05-RT9006','legacy-RT-id');
```