### PR TITLE
feat: improve manual acknowledgment step UI and behavior

### DIFF
--- a/apps/backend/src/features/declarants/declarants.notification.service.test.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.test.ts
@@ -199,13 +199,14 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       'ARS Normandie',
       'Adresse e-mail : contact-ars@ex.com',
       'Téléphone : 02 31 00 00 00',
-      'Adresse postale : 1 rue Example, 76000 Rouen',
+      'Adresse postale :',
+      '1 rue Example, 76000 Rouen',
       '',
       'CD Calvados',
       'Adresse e-mail : contact-cd@ex.com',
     ];
     const expectedEntiteComplete: Record<string, string | number> = {
-      entitecomplete_nb: 7,
+      entitecomplete_nb: 8,
     };
     linesFormulaire.forEach((line, i) => {
       expectedEntiteComplete[`entitecomplete_${i + 1}`] = line;

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -68,7 +68,7 @@ function formatEntiteCompleteString(
         parts.push(`Téléphone : ${entite.telContactUsager}`);
       }
       if (entite.adresseContactUsager) {
-        parts.push(`Adresse postale : ${entite.adresseContactUsager}`);
+        parts.push(`Adresse postale :\n${entite.adresseContactUsager}`);
       }
       return parts.join('\n');
     })

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -82,11 +82,14 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                 step.createdBy === null &&
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
+              const hasAcknowledgmentEmailSent =
+                step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&
+                step.notes.some((note) => note.texte?.startsWith("Email d'accusé de réception envoyé le"));
               const isDisabled =
                 index === data.data.length - 1 ||
                 step.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ||
                 isAutomaticallyUpdated ||
-                (step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT);
+                (hasAcknowledgmentEmailSent && step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT);
               const isAcknowledgmentSendable =
                 isManualRequest &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.module.css
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.module.css
@@ -10,37 +10,25 @@
   padding: 0 16px 88px 16px;
 }
 
-.dl {
+.separator {
+  border-top: 1px solid var(--border-default-grey);
+  margin: 1rem 0;
+}
+
+.sectionLabel {
   margin: 0;
-  padding: 0;
-}
-
-.dl dd {
-  margin-inline-start: 0 !important;
-}
-
-.emailField {
-  background: #fff;
-  border: 1px solid #929292;
-  border-radius: 4px;
-  padding: 8px 12px;
-  min-height: 2rem;
-  overflow-x: auto;
-  white-space: nowrap;
   font-size: 1rem;
   line-height: 1.5rem;
-  color: #161616;
+  color: var(--text-mention-grey);
 }
 
-.messageField {
-  background: #fff;
-  border: 1px solid #929292;
-  border-radius: 4px;
-  padding: 8px 12px;
-  overflow-y: auto;
-  max-height: 320px;
-  white-space: pre-wrap;
+.messageLink {
+  margin-left: 4px;
+}
+
+.plainText {
+  margin: 0;
   font-size: 1rem;
   line-height: 1.5rem;
-  color: #161616;
+  color: var(--text-default-grey);
 }

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -198,7 +198,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                           {message}
                         </p>
                       </div>
-                      <div className={drawerStyles.separator} aria-hidden="true" />
+                      <div className={drawerStyles.separator} />
                       <Input
                         label="Commentaire personnalisé (facultatif)"
                         hintText="Vous pouvez ajouter des informations ou demander des précisions au déclarant. Ce commentaire sera intégré au message automatique."

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -189,7 +189,7 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                           </p>
                         )}
                       </div>
-                      <div className={drawerStyles.separator} aria-hidden="true" />
+                      <div className={drawerStyles.separator} />
                       <div className="fr-form-group fr-mb-2w">
                         <p className={`${drawerStyles.sectionLabel} fr-mb-1w`}>
                           Message automatique envoyé au déclarant

--- a/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
+++ b/apps/frontend/src/components/requestId/processing/SendAcknowledgmentDrawer.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@codegouvfr/react-dsfr/Button';
 import { Input } from '@codegouvfr/react-dsfr/Input';
 import { Drawer, Toast } from '@sirena/ui';
-import { useParams } from '@tanstack/react-router';
+import { Link, useParams } from '@tanstack/react-router';
 
 import { forwardRef, useEffect, useId, useImperativeHandle, useRef, useState } from 'react';
 import { useSendAcknowledgment } from '@/hooks/mutations/updateProcessingStep.hook';
@@ -161,29 +161,44 @@ export const SendAcknowledgmentDrawer = forwardRef<SendAcknowledgmentDrawerRef, 
                   ) : (
                     <form>
                       <div className="fr-form-group fr-mb-2w">
+                        <p className={`${drawerStyles.sectionLabel} fr-mb-1w`}>Adresse électronique du déclarant</p>
                         {declarantEmail ? (
-                          <dl className={drawerStyles.dl}>
-                            <dt className="fr-label fr-mb-1w">
-                              Adresse électronique du déclarant
-                              <span className="fr-hint-text">
-                                Pour modifier cette adresse, rendez-vous dans la section Déclarant.
-                              </span>
-                            </dt>
-                            <dd className={drawerStyles.emailField}>{declarantEmail}</dd>
-                          </dl>
+                          <>
+                            <p className={drawerStyles.plainText}>{declarantEmail}</p>
+                            <p className="fr-message fr-message--info">
+                              {"Vous pouvez modifier l'adresse électronique depuis les "}
+                              <Link
+                                className={drawerStyles.messageLink}
+                                to="/request/$requestId/declarant"
+                                params={{ requestId }}
+                              >
+                                informations déclarant
+                              </Link>
+                            </p>
+                          </>
                         ) : (
-                          <p className="fr-text--sm fr-error-text">
-                            L&apos;adresse électronique du déclarant n&apos;est pas renseignée. Veuillez la renseigner
-                            dans la section &quot;Déclarant&quot;.
+                          <p className="fr-message fr-message--warning">
+                            {"Renseignez l'adresse électronique dans les "}
+                            <Link
+                              className={drawerStyles.messageLink}
+                              to="/request/$requestId/declarant"
+                              params={{ requestId }}
+                            >
+                              informations du déclarant
+                            </Link>
                           </p>
                         )}
                       </div>
+                      <div className={drawerStyles.separator} aria-hidden="true" />
                       <div className="fr-form-group fr-mb-2w">
-                        <p className="fr-label fr-mb-1w">
-                          Ce message est généré automatiquement et ne peut pas être modifié
+                        <p className={`${drawerStyles.sectionLabel} fr-mb-1w`}>
+                          Message automatique envoyé au déclarant
                         </p>
-                        <p className={drawerStyles.messageField}>{message}</p>
+                        <p className={drawerStyles.plainText} style={{ whiteSpace: 'pre-wrap' }}>
+                          {message}
+                        </p>
                       </div>
+                      <div className={drawerStyles.separator} aria-hidden="true" />
                       <Input
                         label="Commentaire personnalisé (facultatif)"
                         hintText="Vous pouvez ajouter des informations ou demander des précisions au déclarant. Ce commentaire sera intégré au message automatique."

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -546,7 +546,7 @@ const StepComponent = ({
                   })
                 }
               >
-                Note ou fichier
+                Ajouter une note ou un fichier
               </Button>
             )}
           </>

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -121,7 +121,7 @@ const getStepSubtitle = (
   }
   if (type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT) {
     if (statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT) {
-      const sendNote = notes.find((note) => note.uploadedFiles.length > 0);
+      const sendNote = notes.find((note) => note.texte?.startsWith("Email d'accusé de réception envoyé le"));
       const isManualRequest = !!requete?.createdBy;
       if (isManualRequest && sendNote?.author) {
         return (
@@ -129,6 +129,9 @@ const getStepSubtitle = (
             Envoyé le {formatDate(updatedAt)} par {formatAgent(sendNote.author)}
           </>
         );
+      }
+      if (isManualRequest && !sendNote) {
+        return `Marqué comme fait le ${formatDate(updatedAt)}`;
       }
       return `Envoyé automatiquement le ${formatDate(updatedAt)}`;
     }
@@ -190,6 +193,11 @@ const StepComponent = ({
     : false;
 
   const isSystemStep = rest.type !== REQUETE_ETAPE_TYPES.MANUAL || statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE;
+  const isAcknowledgmentStep = rest.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
+  const sendNote = isAcknowledgmentStep
+    ? notes.find((note) => note.texte?.startsWith("Email d'accusé de réception envoyé le"))
+    : undefined;
+  const displayNotes = sendNote ? notes.filter((note) => note.id !== sendNote.id) : notes;
 
   const badges = requeteEtapeStatutBadges.filter((badge) => {
     if (statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) {
@@ -445,8 +453,29 @@ const StepComponent = ({
           </>
         ) : (
           <>
+            {sendNote && sendNote.uploadedFiles.length > 0 && (
+              <ul className="fr-mt-1w fr-mb-2w" style={{ listStyle: 'none', padding: 0 }}>
+                {sendNote.uploadedFiles.map((file: (typeof sendNote.uploadedFiles)[number]) => {
+                  const fileName = (file.metadata as { originalName?: string })?.originalName || 'Unknown';
+                  return (
+                    <li key={file.id} className={styles['request-note__file']}>
+                      <FileDownloadLink
+                        href={`/api/requete-etapes/${id}/file/${file.id}`}
+                        safeHref={`/api/requete-etapes/${id}/file/${file.id}/safe`}
+                        fileName={fileName}
+                        fileId={file.id}
+                        fileSize={file.size}
+                        status={file.status}
+                        scanStatus={file.scanStatus}
+                        sanitizeStatus={file.sanitizeStatus}
+                      />
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
             <div className={styles['request-notes']}>
-              {notes.slice(0, isOpen ? notes.length : 3).map((note: StepType['notes'][number]) => (
+              {displayNotes.slice(0, isOpen ? displayNotes.length : 3).map((note: StepType['notes'][number]) => (
                 <StepNote
                   requestId={requestId}
                   key={note.id}
@@ -485,7 +514,7 @@ const StepComponent = ({
               ))}
             </div>
             <div className={styles['request-notes-distplay']}>
-              {notes.length > 3 && (
+              {displayNotes.length > 3 && (
                 <button type="button" className="fr-btn-link" onClick={() => setIsOpen(!isOpen)}>
                   {isOpen ? 'Masquer' : 'Afficher'} les notes précédentes{' '}
                   <span
@@ -497,7 +526,7 @@ const StepComponent = ({
                 </button>
               )}
             </div>
-            {canEdit && !isSystemStep && (
+            {canEdit && (!isSystemStep || isAcknowledgmentStep) && (
               <Button
                 className={styles['request-step__add-note']}
                 type="button"
@@ -517,7 +546,7 @@ const StepComponent = ({
                   })
                 }
               >
-                Ajouter une note ou un fichier
+                Note ou fichier
               </Button>
             )}
           </>


### PR DESCRIPTION
## Summary

- Redesign acknowledgment drawer: email and auto-generated message shown as plain text, labels styled with mention grey, CSS separators instead of `<hr>`
- Add info/warning notices with link to declarant page for email field
- Add line break after postal address label in generated message
- Show agent name in step subtitle only when email was actually sent from SIRENA
- Allow status modification when step is manually marked as done (no email sent)
- Show AR PDF file outside of its note; hide the system note from the list
- Identify AR note by text content (not by file presence) to avoid ordering bugs
- Add "Note ou fichier" button on acknowledgment step for all statuses
- Fix a11y: remove `role="separator"` from decorative divs, use `aria-hidden` instead