### PR TITLE
fix: department name missing in requetesEntites table for some postal codes

### DIFF
--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -269,7 +269,12 @@ export const getRequetesEntite = async (entiteIds: string[] | null, query: GetRe
     }
   }
 
-  const uniqueDptCodes = [...new Set(cpToDptCode.values())];
+  const allDptCodes = new Set<string>();
+  for (const cp of allCps) {
+    const dptCode = cpToDptCode.get(cp) ?? extractDptCode(cp);
+    if (dptCode) allDptCodes.add(dptCode);
+  }
+  const uniqueDptCodes = [...allDptCodes];
 
   const communesQuery =
     uniqueDptCodes.length > 0


### PR DESCRIPTION
## Summary

- Postal codes not found in `inseePostal` (e.g. cedex codes) were falling back to `extractDptCode` at row-build time, after the commune label query had already run — so their department codes were never looked up and `lib` was always empty
- Fix: compute all department codes (including fallbacks) before querying communes so labels are always resolved