### PR TITLE
SIRENA 597 fix: ensure emailDomain always starts with @

### DIFF
--- a/apps/backend/src/scripts/diff-entites.ts
+++ b/apps/backend/src/scripts/diff-entites.ts
@@ -234,7 +234,12 @@ function mapCsvToRows(csvFileContent: string): { inserts: CsvRow[]; updates: Csv
     const emailContactUsager = (line[idxEmailContactUsager] ?? '').trim() || undefined;
     const telContactUsager = (line[idxTelContactUsager] ?? '').trim() || undefined;
     const adresseContactUsager = (line[idxAdresseContactUsager] ?? '').trim() || undefined;
-    const emailDomain = (line[idxEmailDomain] ?? '').trim() || undefined;
+    const emailDomainRaw = (line[idxEmailDomain] ?? '').trim();
+    const emailDomain = emailDomainRaw
+      ? emailDomainRaw.startsWith('@')
+        ? emailDomainRaw
+        : `@${emailDomainRaw}`
+      : undefined;
     const organizationalUnit = (line[idxOrganizationalUnit] ?? '').trim() || undefined;
     const entiteTypeId = (line[idxEntiteTypeId] ?? '').trim() || undefined;
     const entiteMereIdRaw = idxEntiteMereId !== -1 ? (line[idxEntiteMereId] ?? '').trim() : '';

--- a/packages/db/prisma/migrations/20260519000000_fix_email_domain_prefix/migration.sql
+++ b/packages/db/prisma/migrations/20260519000000_fix_email_domain_prefix/migration.sql
@@ -1,0 +1,5 @@
+UPDATE "public"."Entite"
+SET "emailDomain" = '@' || "emailDomain"
+WHERE "emailDomain" IS NOT NULL
+  AND "emailDomain" != ''
+  AND "emailDomain" NOT LIKE '@%';


### PR DESCRIPTION
## Summary

- Migration to prefix existing `emailDomain` values with `@` where missing
- Normalize `emailDomain` in `diff-entites.ts` import script to always add `@` prefix