### PR TITLE
feat(sirena-617): add entity contact info fallback and auto AR blocking logic

### DIFF
--- a/apps/backend/src/features/declarants/declarants.notification.service.test.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.test.ts
@@ -145,6 +145,7 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       select: {
         id: true,
         nomComplet: true,
+        email: true,
         emailContactUsager: true,
         telContactUsager: true,
         adresseContactUsager: true,
@@ -168,6 +169,7 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       {
         id: 'e1',
         nomComplet: 'ARS Normandie',
+        email: '',
         emailContactUsager: 'contact-ars@ex.com',
         telContactUsager: '02 31 00 00 00',
         adresseContactUsager: '1 rue Example, 76000 Rouen',
@@ -176,6 +178,7 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       {
         id: 'e2',
         nomComplet: 'CD Calvados',
+        email: '',
         emailContactUsager: 'contact-cd@ex.com',
         telContactUsager: '',
         adresseContactUsager: '',
@@ -184,6 +187,7 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       {
         id: 'child1',
         nomComplet: 'UA 14',
+        email: '',
         emailContactUsager: 'contact-ua@ex.com',
         telContactUsager: '',
         adresseContactUsager: '',
@@ -264,6 +268,7 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       {
         id: 'e1',
         nomComplet: 'ARS Normandie',
+        email: '',
         emailContactUsager: 'ars@ex.com',
         telContactUsager: '',
         adresseContactUsager: '',
@@ -317,6 +322,7 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
       {
         id: 'e1',
         nomComplet: 'ARS Normandie',
+        email: '',
         emailContactUsager: 'contact-ars@ex.com',
         telContactUsager: '',
         adresseContactUsager: '',
@@ -340,5 +346,115 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
 
     expect(mockedSendTipimailEmail).not.toHaveBeenCalled();
     expect(mockedCreateChangeLog).not.toHaveBeenCalled();
+  });
+
+  it('should not send email when no entity has any displayable info (neither contact fields nor email)', async () => {
+    mockedPrismaRequete.findUnique.mockResolvedValueOnce({
+      id: 'req1',
+      receptionTypeId: RECEPTION_TYPE.FORMULAIRE,
+      declarant: { identite: { email: 'john@example.com', prenom: 'John', nom: 'Doe' } },
+      requeteEntites: [{ entiteId: 'e1' }, { entiteId: 'e2' }],
+    } as any);
+
+    mockedPrismaEntite.findMany.mockResolvedValueOnce([
+      {
+        id: 'e1',
+        nomComplet: 'ARS Normandie',
+        email: '',
+        emailContactUsager: '',
+        telContactUsager: '',
+        adresseContactUsager: '',
+        entiteMereId: null,
+      },
+      {
+        id: 'e2',
+        nomComplet: 'CD Calvados',
+        email: '',
+        emailContactUsager: '',
+        telContactUsager: '',
+        adresseContactUsager: '',
+        entiteMereId: null,
+      },
+    ] as any);
+
+    await sendDeclarantAcknowledgmentEmail('req1');
+
+    expect(mockedSendTipimailEmail).not.toHaveBeenCalled();
+  });
+
+  it('should send email using fallback email field when contact fields are empty', async () => {
+    mockedPrismaRequete.findUnique.mockResolvedValueOnce({
+      id: 'req1',
+      receptionTypeId: RECEPTION_TYPE.FORMULAIRE,
+      declarant: { identite: { email: 'john@example.com', prenom: 'John', nom: 'Doe' } },
+      requeteEntites: [{ entiteId: 'e1' }],
+    } as any);
+
+    mockedPrismaEntite.findMany.mockResolvedValueOnce([
+      {
+        id: 'e1',
+        nomComplet: 'ARS Normandie',
+        email: 'ars-interne@example.com',
+        emailContactUsager: '',
+        telContactUsager: '',
+        adresseContactUsager: '',
+        entiteMereId: null,
+      },
+    ] as any);
+
+    mockedSendTipimailEmail.mockResolvedValueOnce({ status: 'success' } as any);
+
+    await sendDeclarantAcknowledgmentEmail('req1');
+
+    expect(mockedSendTipimailEmail).toHaveBeenCalled();
+    const call = mockedSendTipimailEmail.mock.calls[0]?.[0];
+    const values = (call as any)?.substitutions?.[0]?.values ?? {};
+    expect(values.entitecomplete_1).toBe('ARS Normandie');
+    expect(values.entitecomplete_2).toBe('Adresse e-mail : ars-interne@example.com');
+    expect(values.entitecomplete_nb).toBe(2);
+  });
+
+  it('should send email with name only when entity has no info at all', async () => {
+    mockedPrismaRequete.findUnique.mockResolvedValueOnce({
+      id: 'req1',
+      receptionTypeId: RECEPTION_TYPE.FORMULAIRE,
+      declarant: { identite: { email: 'john@example.com', prenom: 'John', nom: 'Doe' } },
+      requeteEntites: [{ entiteId: 'e1' }, { entiteId: 'e2' }],
+    } as any);
+
+    // e1 has contact info, e2 has nothing → email is sent, e2 shows name only
+    mockedPrismaEntite.findMany.mockResolvedValueOnce([
+      {
+        id: 'e1',
+        nomComplet: 'ARS Normandie',
+        email: '',
+        emailContactUsager: 'contact@ars.fr',
+        telContactUsager: '',
+        adresseContactUsager: '',
+        entiteMereId: null,
+      },
+      {
+        id: 'e2',
+        nomComplet: 'CD Calvados',
+        email: '',
+        emailContactUsager: '',
+        telContactUsager: '',
+        adresseContactUsager: '',
+        entiteMereId: null,
+      },
+    ] as any);
+
+    mockedSendTipimailEmail.mockResolvedValueOnce({ status: 'success' } as any);
+
+    await sendDeclarantAcknowledgmentEmail('req1');
+
+    expect(mockedSendTipimailEmail).toHaveBeenCalled();
+    const call = mockedSendTipimailEmail.mock.calls[0]?.[0];
+    const values = (call as any)?.substitutions?.[0]?.values ?? {};
+    // ARS Normandie with email, then blank line, then CD Calvados name only
+    expect(values.entitecomplete_1).toBe('ARS Normandie');
+    expect(values.entitecomplete_2).toBe('Adresse e-mail : contact@ars.fr');
+    expect(values.entitecomplete_3).toBe('');
+    expect(values.entitecomplete_4).toBe('CD Calvados');
   });
 });

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -1,4 +1,3 @@
-// Import des deux constantes : REQUETE_ETAPE_TYPES pour le lookup Prisma, REQUETE_ETAPE_STATUT_TYPES pour les transitions de statut
 import { RECEPTION_TYPE, REQUETE_ETAPE_STATUT_TYPES, REQUETE_ETAPE_TYPES } from '@sirena/common/constants';
 import { envVars } from '../../config/env.js';
 import {
@@ -46,30 +45,29 @@ function formatEntiteAdminString(entites: Array<{ nomComplet: string; entiteMere
  * Téléphone : 02 01 02 03 04 05
  * Adresse postale : Bâtiment, Voie, Code postal, Ville
  */
-function formatEntiteCompleteString(
-  entites: Array<{
-    nomComplet: string;
-    emailContactUsager: string;
-    telContactUsager: string;
-    adresseContactUsager: string;
-    entiteMereId: string | null;
-  }>,
-): string {
+function formatEntiteCompleteString(entites: EntiteForMessage[]): string {
   // Filter only administrative entities
   const entitesAdmin = entites.filter((e) => e.entiteMereId === null);
 
   return entitesAdmin
     .map((entite) => {
       const parts: string[] = [entite.nomComplet];
-      if (entite.emailContactUsager) {
-        parts.push(`Adresse e-mail : ${entite.emailContactUsager}`);
+      const hasContactInfo = entite.emailContactUsager || entite.telContactUsager || entite.adresseContactUsager;
+      if (hasContactInfo) {
+        if (entite.emailContactUsager) {
+          parts.push(`Adresse e-mail : ${entite.emailContactUsager}`);
+        }
+        if (entite.telContactUsager) {
+          parts.push(`Téléphone : ${entite.telContactUsager}`);
+        }
+        if (entite.adresseContactUsager) {
+          parts.push(`Adresse postale :\n${entite.adresseContactUsager}`);
+        }
+      } else if (entite.email) {
+        // Fallback: no usager contact fields but an internal email is available
+        parts.push(`Adresse e-mail : ${entite.email}`);
       }
-      if (entite.telContactUsager) {
-        parts.push(`Téléphone : ${entite.telContactUsager}`);
-      }
-      if (entite.adresseContactUsager) {
-        parts.push(`Adresse postale :\n${entite.adresseContactUsager}`);
-      }
+      // Otherwise: name only (no info available)
       return parts.join('\n');
     })
     .join('\n\n');
@@ -261,6 +259,7 @@ async function attachEmailPdfToStep(
 
 type EntiteForMessage = {
   nomComplet: string;
+  email: string;
   emailContactUsager: string;
   telContactUsager: string;
   adresseContactUsager: string;
@@ -363,6 +362,7 @@ export async function sendManualAcknowledgmentEmail({
         select: {
           id: true,
           nomComplet: true,
+          email: true,
           emailContactUsager: true,
           telContactUsager: true,
           adresseContactUsager: true,
@@ -537,6 +537,7 @@ export async function sendDeclarantAcknowledgmentEmail(requeteId: string): Promi
       select: {
         id: true,
         nomComplet: true,
+        email: true,
         emailContactUsager: true,
         telContactUsager: true,
         adresseContactUsager: true,
@@ -546,6 +547,16 @@ export async function sendDeclarantAcknowledgmentEmail(requeteId: string): Promi
 
     if (entites.length === 0) {
       logger.debug({ requeteId }, 'No active entities found for this requete, skipping acknowledgment email');
+      return;
+    }
+
+    // Do not send if no admin entity has any displayable info
+    const entitesAdmin = entites.filter((e) => e.entiteMereId === null);
+    const hasAnyDisplayableInfo = entitesAdmin.some(
+      (e) => e.emailContactUsager || e.telContactUsager || e.adresseContactUsager || e.email,
+    );
+    if (!hasAnyDisplayableInfo) {
+      logger.warn({ requeteId }, 'No displayable info on any entity, skipping acknowledgment email');
       return;
     }
 

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
@@ -481,6 +481,7 @@ const app = factoryWithLogs
         select: {
           id: true,
           nomComplet: true,
+          email: true,
           emailContactUsager: true,
           telContactUsager: true,
           adresseContactUsager: true,


### PR DESCRIPTION
Improves the declarant acknowledgment email logic:

- Each entity now falls back to its internal `email` field when no usager contact fields are filled (emailContactUsager, telContactUsager, adresseContactUsager). If none of those are available either, only the entity name is shown.
- In auto mode, the email is blocked (step stays A_FAIRE, no PDF) only when no admin entity has any displayable info at all — including the fallback email.
- In manual mode, the agent can always send regardless of available info.