### PR TITLE
fix: ignorer ownership et privilèges à la restauration anonymisée

### DIFF
--- a/apps/anonymize/greenmask.yml
+++ b/apps/anonymize/greenmask.yml
@@ -314,6 +314,11 @@ restore:
     dbname: "${PG_URL_TO}"
     jobs: 4
     exit-on-error: true
+    # La source (OVH) et la cible (CNPG) n'ont pas les mêmes rôles :
+    # on saute les ALTER OWNER et GRANT/REVOKE du dump, les objets
+    # appartiennent au rôle de connexion de PG_URL_TO.
+    no-owner: true
+    no-privileges: true
 
 # Limite la sortie de `greenmask validate` aux seules colonnes
 # transformees (plus la PK) au lieu d'afficher toutes les colonnes


### PR DESCRIPTION
## Problème

Sur **formation**, le job d'anonymisation échoue à la restauration :

```
pg_restore: error: could not execute query: ERROR:  role "avnadmin" does not exist
Command was: ALTER SCHEMA public OWNER TO avnadmin;
```

La base source est une base managée OVH (objets possédés par `avnadmin`), la base cible est une base CNPG où ce rôle n'existe pas. Avec `exit-on-error: true`, le premier `ALTER ... OWNER TO` tue la restauration dès la section pre-data.

## Correctif

Ajout de `no-owner: true` et `no-privileges: true` aux `pg_restore_options` de Greenmask :

- `no-owner` : les objets restaurés appartiennent au rôle de connexion de `PG_URL_TO` — le rôle que les consommateurs de la base anonymisée utilisent déjà.
- `no-privileges` : saute les `GRANT`/`REVOKE` du dump, qui référencent aussi des rôles OVH inexistants côté CNPG.

## Impact sur les autres environnements

L'image étant partagée par tous les environnements, le changement s'applique partout :

- Sur les envs où source et cible partagent le même rôle, `no-owner` est un no-op (résultat identique).
- Le seul consommateur de la base anonymisée référencé est le secret `databases/sirena-<env>-anonymisation`, c'est-à-dire le rôle de restauration lui-même, propriétaire de tous les objets — aucun `GRANT` du dump n'est nécessaire.
