### PR TITLE
fix: recherche entité (accents, tirets, 1 caractère) et alignement direction

### DIFF
--- a/apps/frontend/src/components/common/EntiteCombobox.tsx
+++ b/apps/frontend/src/components/common/EntiteCombobox.tsx
@@ -12,7 +12,21 @@ interface EntiteComboboxProps {
   required?: boolean;
 }
 
-const MIN_FILTER_LENGTH = 3;
+const MIN_FILTER_LENGTH = 1;
+
+const normalizeSearchText = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/-/g, ' ')
+    .toLowerCase();
+
+const matchesSearch = (nomComplet: string, search: string) => {
+  const terms = normalizeSearchText(search).trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return true;
+  const searchable = normalizeSearchText(nomComplet);
+  return terms.every((term) => searchable.includes(term));
+};
 
 export function EntiteCombobox({
   entites,
@@ -48,7 +62,7 @@ export function EntiteCombobox({
   const filteredEntites = useMemo(
     () =>
       hasTyped && inputValue.length >= MIN_FILTER_LENGTH
-        ? entites.filter((e) => e.nomComplet.toLowerCase().includes(inputValue.toLowerCase()))
+        ? entites.filter((e) => matchesSearch(e.nomComplet, inputValue))
         : entites,
     [hasTyped, inputValue, entites],
   );

--- a/apps/frontend/src/components/situation/TraitementDesFaits.tsx
+++ b/apps/frontend/src/components/situation/TraitementDesFaits.tsx
@@ -131,6 +131,7 @@ function TraitementDesFaitsRowComponent({
                 value: entite.id,
               }))}
               label="Direction ou Service"
+              hint={isEntiteReadOnly ? undefined : 'Sélectionnez dans la liste'}
             />
           )}
         </div>

--- a/packages/ui/src/components/SelectWithChildren/SelectWithChildren.tsx
+++ b/packages/ui/src/components/SelectWithChildren/SelectWithChildren.tsx
@@ -22,6 +22,7 @@ export function SelectWithChildren({
   value,
   onChange,
   label = "Motifs qualifiés par l'agent",
+  hint,
   options,
   id,
   disabled = false,
@@ -82,6 +83,7 @@ export function SelectWithChildren({
     <div className="fr-select-group">
       <label className="fr-label" htmlFor={buttonId}>
         {label}
+        {hint && <span className="fr-hint-text">{hint}</span>}
       </label>
 
       <div className={styles.selectWrapper} ref={dropdownRef}>

--- a/packages/ui/src/components/SelectWithChildren/SelectWithChildren.types.ts
+++ b/packages/ui/src/components/SelectWithChildren/SelectWithChildren.types.ts
@@ -8,6 +8,7 @@ export interface SelectWithChildrenProps {
   value: string[];
   onChange: (values: string[]) => void;
   label?: string;
+  hint?: string;
   options: SelectWithChildrenOption[];
   id?: string;
   disabled?: boolean;


### PR DESCRIPTION
Retours SIRENA-592 sur le combobox « Entité administrative » :

- Filtrage de la liste dès **1 caractère** (au lieu de 3).
- Recherche **insensible aux accents et aux tirets** (et toujours à la casse) ; apostrophes et espaces conservés.
- Réalignement en hauteur du champ « Direction ou Service » avec le champ entité