### PR TITLE
feat(db): data migrations — step files, AR sender, EN_COURS status (PR2)

### DIFF
--- a/packages/db/prisma/migrations/20260620223422_backfill_uploaded_file_requete_etape/migration.sql
+++ b/packages/db/prisma/migrations/20260620223422_backfill_uploaded_file_requete_etape/migration.sql
@@ -1,0 +1,6 @@
+-- Link each note's files to the note's step (idempotent).
+UPDATE "UploadedFile" uf
+SET "requeteEtapeId" = n."requeteEtapeId"
+FROM "RequeteEtapeNote" n
+WHERE uf."requeteEtapeNoteId" = n."id"
+  AND uf."requeteEtapeId" IS NULL;

--- a/packages/db/prisma/migrations/20260620223501_backfill_acknowledgment_uploaded_by/migration.sql
+++ b/packages/db/prisma/migrations/20260620223501_backfill_acknowledgment_uploaded_by/migration.sql
@@ -1,0 +1,7 @@
+-- Preserve the acknowledgment sender on the file before system notes are dropped.
+UPDATE "UploadedFile" uf
+SET "uploadedById" = n."authorId"
+FROM "RequeteEtapeNote" n
+WHERE uf."requeteEtapeNoteId" = n."id"
+  AND uf."uploadedById" IS NULL
+  AND n."authorId" IS NOT NULL;

--- a/packages/db/prisma/migrations/20260620223531_clear_en_cours_statut/migration.sql
+++ b/packages/db/prisma/migrations/20260620223531_clear_en_cours_statut/migration.sql
@@ -1,0 +1,2 @@
+-- Remove the "En cours" step status: affected steps become null (irreversible).
+UPDATE "RequeteEtape" SET "statutId" = NULL WHERE "statutId" = 'EN_COURS';


### PR DESCRIPTION
## Les 3 migrations 

### Migration 1 — `backfill_uploaded_file_requete_etape`
Rattache chaque fichier porté par une note à **l'étape** de cette note (couvre notes manuelles, clôture et AR).
```sql
UPDATE "UploadedFile" uf SET "requeteEtapeId" = n."requeteEtapeId"
FROM "RequeteEtapeNote" n
WHERE uf."requeteEtapeNoteId" = n."id" AND uf."requeteEtapeId" IS NULL;
```

### Migration 2 — `backfill_acknowledgment_uploaded_by`
Transvase « qui a envoyé l'AR » de la note vers le fichier (`uploadedById`), **avant** la suppression future des notes système d'AR. Cible : fichiers de note sans `uploadedById` dont la note a un auteur (= AR manuels). AR automatiques (`authorId` null) non touchés → restent « ajouté automatiquement ».
```sql
UPDATE "UploadedFile" uf SET "uploadedById" = n."authorId"
FROM "RequeteEtapeNote" n
WHERE uf."requeteEtapeNoteId" = n."id" AND uf."uploadedById" IS NULL AND n."authorId" IS NOT NULL;
```


### Migration 3 — `clear_en_cours_statut`
Les étapes au statut « En cours » passent **sans statut** (`NULL`).
```sql
UPDATE "RequeteEtape" SET "statutId" = NULL WHERE "statutId" = 'EN_COURS';
```

