### PR TITLE
feat: endpoint consolidé transactionnel pour les étapes (SIRENA-635 — PR3)

### DIFF
--- a/apps/backend/src/features/requeteEtapes/requeteEtapes.controller.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requeteEtapes.controller.test.ts
@@ -17,10 +17,12 @@ import {
 import { getUploadedFileById } from '../uploadedFiles/uploadedFiles.service.js';
 import RequeteEtapesController from './requetesEtapes.controller.js';
 import {
-  addProcessingEtape,
+  createProcessingEtape,
   deleteRequeteEtape,
+  EtapeNotEditableError,
   getRequeteEtapeById,
   getRequeteEtapes,
+  updateProcessingEtape,
   updateRequeteEtapeNom,
   updateRequeteEtapeStatut,
 } from './requetesEtapes.service.js';
@@ -36,7 +38,10 @@ vi.mock('../requeteEtapes/requetesEtapes.service.js', () => ({
   updateRequeteEtapeStatut: vi.fn(),
   updateRequeteEtapeNom: vi.fn(() => Promise.resolve(fakeUpdatedNomRequeteEtape)),
   deleteRequeteEtape: vi.fn(),
-  addProcessingEtape: vi.fn(),
+  createProcessingEtape: vi.fn(),
+  updateProcessingEtape: vi.fn(),
+  EtapeNotEditableError: class EtapeNotEditableError extends Error {},
+  FilesNotOwnedError: class FilesNotOwnedError extends Error {},
   getRequeteEtapes: vi.fn(),
 }));
 
@@ -675,7 +680,7 @@ describe('requeteEtapes.controller.ts', () => {
         clotureEffectiveDate: null,
       };
 
-      vi.mocked(addProcessingEtape).mockResolvedValueOnce(fakeStep);
+      vi.mocked(createProcessingEtape).mockResolvedValueOnce(fakeStep);
 
       const res = await client[':id']['processing-steps'].$post({
         param: { id: '1' },
@@ -685,12 +690,22 @@ describe('requeteEtapes.controller.ts', () => {
       expect(res.status).toBe(201);
       const json = await res.json();
       expect(json).toEqual({ data: convertDatesToStrings(fakeStep) });
-      expect(addProcessingEtape).toHaveBeenCalledWith('1', 'e1', { nom: 'Step 1' }, 'test-user-id');
+      expect(createProcessingEtape).toHaveBeenCalledWith(
+        '1',
+        'e1',
+        'test-user-id',
+        {
+          nom: 'Step 1',
+          notes: [],
+          fileIds: [],
+        },
+        expect.anything(),
+      );
     });
 
     it('should return 404 if hasAccessToRequete returns false', async () => {
       vi.mocked(hasAccessToRequete).mockResolvedValueOnce(false);
-      vi.mocked(addProcessingEtape).mockResolvedValueOnce(null);
+      vi.mocked(createProcessingEtape).mockResolvedValueOnce(null);
 
       const res = await client[':id']['processing-steps'].$post({
         param: { id: 'nonexistent' },
@@ -705,7 +720,7 @@ describe('requeteEtapes.controller.ts', () => {
     it('should return 404 if step is not created', async () => {
       vi.mocked(hasAccessToRequete).mockResolvedValueOnce(true);
 
-      vi.mocked(addProcessingEtape).mockResolvedValueOnce(null);
+      vi.mocked(createProcessingEtape).mockResolvedValueOnce(null);
 
       const res = await client[':id']['processing-steps'].$post({
         param: { id: '1' },
@@ -715,7 +730,69 @@ describe('requeteEtapes.controller.ts', () => {
       expect(res.status).toBe(404);
       const json = await res.json();
       expect(json).toEqual({ message: 'Requete entite not found', cause: { kind: ERROR_KIND.BUSINESS } });
-      expect(addProcessingEtape).toHaveBeenCalledWith('1', 'e1', { nom: 'Step 1' }, 'test-user-id');
+      expect(createProcessingEtape).toHaveBeenCalledWith(
+        '1',
+        'e1',
+        'test-user-id',
+        {
+          nom: 'Step 1',
+          notes: [],
+          fileIds: [],
+        },
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('PATCH /:id', () => {
+    const validBody = { nom: 'Updated', statutId: 'A_FAIRE' as const, notes: [], fileIds: [] };
+
+    it('updates a step and returns 200', async () => {
+      vi.mocked(getRequeteEtapeById).mockResolvedValueOnce(fakeRequeteEtape);
+      vi.mocked(updateProcessingEtape).mockResolvedValueOnce(fakeUpdatedNomRequeteEtape);
+
+      const res = await client[':id'].$patch({ param: { id: 'step1' }, json: validBody });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({ data: convertDatesToStrings(fakeUpdatedNomRequeteEtape) });
+      expect(updateProcessingEtape).toHaveBeenCalledWith('step1', 'test-user-id', validBody, expect.anything());
+    });
+
+    it('returns 404 if RequeteEtape not found', async () => {
+      vi.mocked(getRequeteEtapeById).mockResolvedValueOnce(null);
+
+      const res = await client[':id'].$patch({ param: { id: 'nope' }, json: validBody });
+
+      expect(res.status).toBe(404);
+      expect(updateProcessingEtape).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 if the step belongs to another entite', async () => {
+      vi.mocked(getRequeteEtapeById).mockResolvedValueOnce({ ...fakeRequeteEtape, entiteId: 'other-entite' });
+
+      const res = await client[':id'].$patch({ param: { id: 'step1' }, json: validBody });
+
+      expect(res.status).toBe(403);
+      expect(updateProcessingEtape).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 if the step is not editable', async () => {
+      vi.mocked(getRequeteEtapeById).mockResolvedValueOnce(fakeRequeteEtape);
+      vi.mocked(updateProcessingEtape).mockRejectedValueOnce(new EtapeNotEditableError('ETAPE_NOT_EDITABLE'));
+
+      const res = await client[':id'].$patch({ param: { id: 'step1' }, json: validBody });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('validates the body (status EN_COURS is rejected)', async () => {
+      const res = await client[':id'].$patch({
+        param: { id: 'step1' },
+        json: { ...validBody, statutId: 'EN_COURS' as never },
+      });
+
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.controller.ts
@@ -36,6 +36,7 @@ import {
   addProcessingStepRoute,
   deleteRequeteEtapeRoute,
   sendAcknowledgmentRoute,
+  updateProcessingStepRoute,
   updateRequeteEtapeDateRealisationRoute,
   updateRequeteEtapeNomRoute,
   updateRequeteEtapeStatutRoute,
@@ -43,15 +44,19 @@ import {
 import {
   AddProcessingStepBodySchema,
   SendAcknowledgmentBodySchema,
+  UpdateProcessingStepBodySchema,
   UpdateRequeteEtapeDateRealisationSchema,
   UpdateRequeteEtapeNomSchema,
   UpdateRequeteEtapeStatutSchema,
 } from './requetesEtapes.schema.js';
 import {
-  addProcessingEtape,
+  createProcessingEtape,
   deleteRequeteEtape,
+  EtapeNotEditableError,
+  FilesNotOwnedError,
   getRequeteEtapeById,
   getRequeteEtapes,
+  updateProcessingEtape,
   updateRequeteEtapeDateRealisation,
   updateRequeteEtapeNom,
   updateRequeteEtapeStatut,
@@ -216,14 +221,18 @@ const app = factoryWithLogs
         await updateStatusRequete(requeteId, topEntiteId, REQUETE_STATUT_TYPES.EN_COURS);
       }
 
-      const step = await addProcessingEtape(
-        requeteId,
-        topEntiteId,
-        {
-          nom: body.nom,
-        },
-        userId,
-      );
+      let step: Awaited<ReturnType<typeof createProcessingEtape>>;
+      try {
+        step = await createProcessingEtape(requeteId, topEntiteId, userId, body, logger);
+      } catch (err) {
+        if (err instanceof FilesNotOwnedError) {
+          throwHTTPException403Forbidden('You are not allowed to add these files', {
+            res: c.res,
+            kind: ERROR_KIND.BUSINESS,
+          });
+        }
+        throw err;
+      }
 
       if (!step) {
         logger.error({ requestId: requeteId, userId }, 'Inconsistent state: step not created');
@@ -238,6 +247,78 @@ const app = factoryWithLogs
       logger.info({ requestId: requeteId, stepId: step.id, userId }, 'Processing step added successfully');
 
       return c.json({ data: step }, 201);
+    },
+  )
+  .patch(
+    '/:id',
+    updateProcessingStepRoute,
+    zValidator('json', UpdateProcessingStepBodySchema),
+    requeteEtapesChangelogMiddleware({ action: ChangeLogAction.UPDATED }),
+    async (c) => {
+      const logger = c.get('logger');
+      const { id: stepId } = c.req.param();
+      const body = c.req.valid('json');
+      const userId = c.get('userId');
+      const topEntiteId = c.get('topEntiteId');
+      if (!topEntiteId) {
+        throwHTTPException400BadRequest('You are not allowed to update requetes without topEntiteId.', {
+          res: c.res,
+          kind: ERROR_KIND.BUSINESS,
+        });
+      }
+
+      const etape = await getRequeteEtapeById(stepId);
+      if (!etape) {
+        throwHTTPException404NotFound('RequeteEtape not found', { res: c.res, kind: ERROR_KIND.BUSINESS });
+      }
+      if (topEntiteId !== etape.entiteId) {
+        throwHTTPException403Forbidden('You are not allowed to update this requete etape', {
+          res: c.res,
+          kind: ERROR_KIND.BUSINESS,
+        });
+      }
+
+      const hasAccess = await hasAccessToRequete({ requeteId: etape.requeteId, entiteId: topEntiteId });
+      if (!hasAccess) {
+        throwHTTPException403Forbidden('You are not allowed to update this requete etape', {
+          res: c.res,
+          kind: ERROR_KIND.BUSINESS,
+        });
+      }
+
+      // Working on a step moves the requete from NOUVEAU to EN_COURS
+      // (parity with the legacy PATCH /:id/nom and /:id/statut, and with the POST).
+      const requete = await getRequeteEntiteById(etape.requeteId, topEntiteId);
+      if (requete?.statutId === REQUETE_STATUT_TYPES.NOUVEAU) {
+        await updateStatusRequete(etape.requeteId, topEntiteId, REQUETE_STATUT_TYPES.EN_COURS);
+      }
+
+      let updated: Awaited<ReturnType<typeof updateProcessingEtape>>;
+      try {
+        updated = await updateProcessingEtape(stepId, userId, body, logger);
+      } catch (err) {
+        if (err instanceof EtapeNotEditableError) {
+          throwHTTPException403Forbidden("Cette étape n'est pas modifiable.", {
+            res: c.res,
+            kind: ERROR_KIND.BUSINESS,
+          });
+        }
+        if (err instanceof FilesNotOwnedError) {
+          throwHTTPException403Forbidden('You are not allowed to add these files', {
+            res: c.res,
+            kind: ERROR_KIND.BUSINESS,
+          });
+        }
+        throw err;
+      }
+
+      if (!updated) {
+        throwHTTPException404NotFound('RequeteEtape not found', { res: c.res, kind: ERROR_KIND.BUSINESS });
+      }
+
+      c.set('changelogId', stepId);
+      logger.info({ stepId, userId }, 'Processing step updated successfully');
+      return c.json({ data: updated });
     },
   )
   .patch(

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.route.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.route.ts
@@ -21,6 +21,13 @@ export const getProcessingStepsRoute = openApiProtectedRoute({
   },
 });
 
+export const updateProcessingStepRoute = openApiProtectedRoute({
+  description: 'Update a processing step (name, status, date, notes and files)',
+  responses: {
+    ...openApiResponse(RequeteEtapeSchema),
+  },
+});
+
 export const addProcessingStepNoteRoute = openApiProtectedRoute({
   description: 'Add a processing note to a step of a request',
   responses: {

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.schema.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.schema.ts
@@ -55,10 +55,12 @@ const noteTexteSchema = z
     z
       .string()
       .min(1, { message: 'Le texte de la note est obligatoire.' })
-      .max(100000, { message: 'Maximum 10 000 caractères.' }),
+      .max(10_000, { message: 'Maximum 10 000 caractères.' }),
   );
 
-const fileIdsSchema = z.array(z.string().min(1, 'id vide'));
+const fileIdsSchema = z.array(z.string().min(1, 'id vide')).refine((ids) => new Set(ids).size === ids.length, {
+  message: 'Les fichiers ne doivent pas être dupliqués.',
+});
 
 // DateRealisation is mandatory when statut is « Fait ».
 const requireDateWhenFait = (data: { statutId?: string | null; dateRealisation?: Date }) =>

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.schema.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.schema.ts
@@ -39,11 +39,54 @@ const columns = [
   Prisma.RequeteEtapeScalarFieldEnum.statutId,
 ] as const;
 
-export const AddProcessingStepBodySchema = z.object({
-  nom: z
-    .string()
-    .min(1, { message: "Le champ 'Nom de l'étape' est obligatoire. Veuillez le renseigner pour ajouter une étape." }),
-});
+const etapeNomSchema = z
+  .string()
+  .min(1, { message: "Le champ 'Nom de l'étape' est obligatoire. Veuillez le renseigner pour ajouter une étape." })
+  .max(300, { message: `Le nom de l'étape ne peut pas dépasser 300 caractères.` })
+  .transform((str) => str.trim().replace(/[<>]/g, '').replace(/\s+/g, ' '))
+  .refine((val) => val.length > 0, { message: "Le nom de l'étape ne peut pas être vide." });
+
+const etapeStatutEnum = z.enum([REQUETE_ETAPE_STATUT_TYPES.A_FAIRE, REQUETE_ETAPE_STATUT_TYPES.FAIT]);
+
+const noteTexteSchema = z
+  .string()
+  .transform((s) => s.trim())
+  .pipe(
+    z
+      .string()
+      .min(1, { message: 'Le texte de la note est obligatoire.' })
+      .max(100000, { message: 'Maximum 10 000 caractères.' }),
+  );
+
+const fileIdsSchema = z.array(z.string().min(1, 'id vide'));
+
+// DateRealisation is mandatory when statut is « Fait ».
+const requireDateWhenFait = (data: { statutId?: string | null; dateRealisation?: Date }) =>
+  data.statutId !== REQUETE_ETAPE_STATUT_TYPES.FAIT || data.dateRealisation != null;
+
+export const AddProcessingStepBodySchema = z
+  .object({
+    nom: etapeNomSchema,
+    statutId: etapeStatutEnum.optional(),
+    dateRealisation: z.coerce.date().optional(),
+    notes: z
+      .array(z.object({ texte: noteTexteSchema }))
+      .optional()
+      .default([]),
+    fileIds: fileIdsSchema.optional().default([]),
+  })
+  .refine(requireDateWhenFait, { path: ['dateRealisation'], message: 'La date de réalisation est obligatoire.' });
+
+export const UpdateProcessingStepBodySchema = z
+  .object({
+    nom: etapeNomSchema,
+    statutId: etapeStatutEnum,
+    dateRealisation: z.coerce.date().optional(),
+
+    notes: z.array(z.object({ id: z.string().optional(), texte: noteTexteSchema })).default([]),
+    fileIds: fileIdsSchema.default([]),
+  })
+  .refine(requireDateWhenFait, { path: ['dateRealisation'], message: 'La date de réalisation est obligatoire.' });
 
 export const GetRequeteEtapesQuerySchema = paginationQueryParamsSchema(columns);
 

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -11,12 +11,17 @@ import {
   type UploadedFile,
 } from '../../libs/prisma.js';
 import { createChangeLog } from '../changelog/changelog.service.js';
+import { isUserOwner, setEtapeFile } from '../uploadedFiles/uploadedFiles.service.js';
 import {
-  addProcessingEtape,
   createDefaultRequeteEtapes,
+  createProcessingEtape,
   deleteRequeteEtape,
+  EtapeNotEditableError,
+  FilesNotOwnedError,
+  getEtapeEditability,
   getRequeteEtapeById,
   getRequeteEtapes,
+  updateProcessingEtape,
   updateRequeteEtapeNom,
   updateRequeteEtapeStatut,
 } from './requetesEtapes.service.js';
@@ -52,6 +57,11 @@ vi.mock('../changelog/changelog.service.js', () => ({
 
 vi.mock('../../libs/minio.js', () => ({
   deleteFileFromMinio: vi.fn(),
+}));
+
+vi.mock('../uploadedFiles/uploadedFiles.service.js', () => ({
+  isUserOwner: vi.fn(() => Promise.resolve(true)),
+  setEtapeFile: vi.fn(() => Promise.resolve([])),
 }));
 
 const requeteEtape: RequeteEtape = {
@@ -454,142 +464,6 @@ describe('RequeteEtapes.service.ts', () => {
     });
   });
 
-  describe('addProcessingEtape()', () => {
-    it('should add a processing etape when requete exists', async () => {
-      const mockRequete = {
-        id: 'requeteId',
-        commentaire: 'Test',
-        receptionDate: new Date('2024-01-15T10:00:00Z'),
-        dateDemandeDeclarant: null,
-        dematSocialId: 123,
-        sirecId: null,
-        receptionTypeId: 'type',
-        createdById: null,
-        provenanceId: null,
-        provenancePrecision: null,
-        thirdPartyAccountId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      vi.mocked(prisma.requete.findUnique).mockReset();
-      vi.mocked(prisma.requeteEntite.upsert).mockReset();
-      vi.mocked(prisma.requeteEtape.create).mockReset();
-
-      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequete);
-      vi.mocked(prisma.requeteEntite.upsert).mockResolvedValueOnce(requeteEntite);
-      vi.mocked(prisma.requeteEtape.create).mockResolvedValueOnce(requeteEtape);
-
-      const result = await addProcessingEtape('requeteId', 'entiteId', {
-        nom: requeteEtape.nom,
-      });
-
-      expect(result).toEqual(requeteEtape);
-      expect(prisma.requete.findUnique).toHaveBeenCalledWith({
-        where: { id: 'requeteId' },
-      });
-      expect(prisma.requeteEntite.upsert).toHaveBeenCalledWith({
-        where: {
-          requeteId_entiteId: {
-            requeteId: 'requeteId',
-            entiteId: 'entiteId',
-          },
-        },
-        create: {
-          requeteId: 'requeteId',
-          entiteId: 'entiteId',
-          statutId: 'NOUVEAU',
-        },
-        update: {},
-      });
-      expect(prisma.requeteEtape.create).toHaveBeenCalledWith({
-        data: {
-          requeteId: requeteEtape.requeteId,
-          entiteId: requeteEtape.entiteId,
-          nom: requeteEtape.nom,
-          type: 'MANUAL',
-          statutId: requeteEtape.statutId,
-        },
-      });
-    });
-
-    it('should return null if requete does not exist', async () => {
-      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(null);
-
-      const result = await addProcessingEtape('nonExistentRequeteId', 'entiteId', {
-        nom: 'Processing Etape',
-      });
-
-      expect(result).toBeNull();
-      expect(prisma.requeteEntite.upsert).not.toHaveBeenCalled();
-      expect(prisma.requeteEtape.create).not.toHaveBeenCalled();
-    });
-
-    it('should add a processing etape with userId', async () => {
-      const mockRequete = {
-        id: 'requeteId',
-        commentaire: 'Test',
-        receptionDate: new Date('2024-01-15T10:00:00Z'),
-        dateDemandeDeclarant: null,
-        dematSocialId: 123,
-        sirecId: null,
-        receptionTypeId: 'type',
-        createdById: null,
-        provenanceId: null,
-        provenancePrecision: null,
-        thirdPartyAccountId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      };
-
-      vi.mocked(prisma.requete.findUnique).mockReset();
-      vi.mocked(prisma.requeteEntite.upsert).mockReset();
-      vi.mocked(prisma.requeteEtape.create).mockReset();
-
-      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce(mockRequete);
-      vi.mocked(prisma.requeteEntite.upsert).mockResolvedValueOnce(requeteEntite);
-      vi.mocked(prisma.requeteEtape.create).mockResolvedValueOnce(requeteEtape);
-
-      const result = await addProcessingEtape(
-        'requeteId',
-        'entiteId',
-        {
-          nom: requeteEtape.nom,
-        },
-        'userId',
-      );
-
-      expect(result).toEqual(requeteEtape);
-      expect(prisma.requete.findUnique).toHaveBeenCalledWith({
-        where: { id: 'requeteId' },
-      });
-      expect(prisma.requeteEntite.upsert).toHaveBeenCalledWith({
-        where: {
-          requeteId_entiteId: {
-            requeteId: 'requeteId',
-            entiteId: 'entiteId',
-          },
-        },
-        create: {
-          requeteId: 'requeteId',
-          entiteId: 'entiteId',
-          statutId: 'NOUVEAU',
-        },
-        update: {},
-      });
-      expect(prisma.requeteEtape.create).toHaveBeenCalledWith({
-        data: {
-          requeteId: requeteEtape.requeteId,
-          entiteId: requeteEtape.entiteId,
-          nom: requeteEtape.nom,
-          type: 'MANUAL',
-          statutId: requeteEtape.statutId,
-          createdById: 'userId',
-        },
-      });
-    });
-  });
-
   describe('getRequeteEtapes()', () => {
     it('should retrieve RequeteEtapes for a given RequeteEntite', async () => {
       vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([requeteEtapeWithNotesAndFiles]);
@@ -983,6 +857,222 @@ describe('RequeteEtapes.service.ts', () => {
 
       expect(createChangeLog).toHaveBeenCalledTimes(2); // 1 note + 1 file
       expect(deleteFileFromMinio).toHaveBeenCalledWith('path/to/file1.pdf');
+    });
+  });
+
+  describe('getEtapeEditability', () => {
+    it('MANUAL step is fully editable', () => {
+      expect(getEtapeEditability({ type: 'MANUAL', statutId: 'A_FAIRE', requete: { createdById: 'agent-1' } })).toEqual(
+        {
+          editable: true,
+          ackNotesOnly: false,
+        },
+      );
+    });
+
+    it('CLOTUREE step is not editable', () => {
+      expect(getEtapeEditability({ type: 'MANUAL', statutId: 'CLOTUREE', requete: { createdById: 'a' } })).toEqual({
+        editable: false,
+        ackNotesOnly: false,
+      });
+    });
+
+    it('CREATION and REOPEN steps are not editable', () => {
+      expect(getEtapeEditability({ type: 'CREATION', statutId: 'FAIT', requete: { createdById: null } }).editable).toBe(
+        false,
+      );
+      expect(getEtapeEditability({ type: 'REOPEN', statutId: 'FAIT', requete: { createdById: 'a' } }).editable).toBe(
+        false,
+      );
+    });
+
+    it('automatic ACR (requete without createdById) is notes-only', () => {
+      expect(getEtapeEditability({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: null } })).toEqual(
+        {
+          editable: true,
+          ackNotesOnly: true,
+        },
+      );
+    });
+
+    it('manual ACR (requete with createdById) is fully editable', () => {
+      expect(
+        getEtapeEditability({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: 'agent-1' } }),
+      ).toEqual({ editable: true, ackNotesOnly: false });
+    });
+  });
+
+  describe('createProcessingEtape', () => {
+    const logger = { error: vi.fn(), info: vi.fn() } as unknown as PinoLogger;
+
+    it('returns null when entiteId is missing', async () => {
+      expect(
+        await createProcessingEtape('req-1', null, 'user-1', { nom: 'X', notes: [], fileIds: [] }, logger),
+      ).toBeNull();
+    });
+
+    it('creates the step, its notes and attaches files in one transaction', async () => {
+      const createdEtape = { ...requeteEtape, id: 'new-step' };
+      vi.mocked(isUserOwner).mockResolvedValue(true);
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce({ id: 'req-1' } as Requete);
+      vi.mocked(prisma.requeteEntite.upsert).mockResolvedValueOnce({} as RequeteEntite);
+
+      const tx = {
+        requeteEtape: { create: vi.fn().mockResolvedValue(createdEtape) },
+        requeteEtapeNote: {
+          create: vi
+            .fn()
+            .mockResolvedValue({ id: 'note-1', texte: 'note 1', authorId: 'user-1', requeteEtapeId: 'new-step' }),
+        },
+        uploadedFile: { updateMany: vi.fn() },
+      };
+      vi.mocked(prisma.$transaction).mockImplementation((async (cb: (t: unknown) => unknown) => cb(tx)) as never);
+
+      const result = await createProcessingEtape(
+        'req-1',
+        'e1',
+        'user-1',
+        {
+          nom: 'Analyse',
+          statutId: 'FAIT',
+          dateRealisation: new Date('2026-05-20'),
+          notes: [{ texte: 'note 1' }],
+          fileIds: ['file-1'],
+        },
+        logger,
+      );
+
+      expect(result).toEqual(createdEtape);
+      expect(tx.requeteEtape.create).toHaveBeenCalledTimes(1);
+      expect(tx.requeteEtapeNote.create).toHaveBeenCalledTimes(1);
+      expect(setEtapeFile).toHaveBeenCalledWith('new-step', ['file-1'], 'e1', 'user-1', tx);
+    });
+
+    it('throws FilesNotOwnedError when the user does not own the files', async () => {
+      vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce({ id: 'req-1' } as Requete);
+      vi.mocked(prisma.requeteEntite.upsert).mockResolvedValueOnce({} as RequeteEntite);
+      vi.mocked(isUserOwner).mockResolvedValue(false);
+
+      await expect(
+        createProcessingEtape('req-1', 'e1', 'user-1', { nom: 'X', notes: [], fileIds: ['not-mine'] }, logger),
+      ).rejects.toBeInstanceOf(FilesNotOwnedError);
+    });
+  });
+
+  describe('updateProcessingEtape', () => {
+    const logger = { error: vi.fn(), info: vi.fn() } as unknown as PinoLogger;
+    const makeTx = () => ({
+      requeteEtape: { update: vi.fn() },
+      requeteEtapeNote: {
+        update: vi.fn(),
+        create: vi
+          .fn()
+          .mockResolvedValue({ id: 'new-note', texte: 'new note', authorId: 'user-1', requeteEtapeId: 'step-1' }),
+        delete: vi.fn(),
+      },
+      uploadedFile: { updateMany: vi.fn(), deleteMany: vi.fn() },
+    });
+
+    it('returns null when the step does not exist', async () => {
+      vi.mocked(prisma.requeteEtape.findUnique).mockResolvedValueOnce(null);
+      const result = await updateProcessingEtape(
+        'nope',
+        'user-1',
+        { nom: 'X', statutId: 'A_FAIRE', notes: [], fileIds: [] },
+        logger,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('throws EtapeNotEditableError for a closed step', async () => {
+      vi.mocked(prisma.requeteEtape.findUnique).mockResolvedValueOnce({
+        id: 'c',
+        type: 'MANUAL',
+        statutId: 'CLOTUREE',
+        entiteId: 'e1',
+        notes: [],
+        uploadedFiles: [],
+        requete: { createdById: 'a' },
+      } as never);
+      await expect(
+        updateProcessingEtape('c', 'user-1', { nom: 'X', statutId: 'A_FAIRE', notes: [], fileIds: [] }, logger),
+      ).rejects.toBeInstanceOf(EtapeNotEditableError);
+    });
+
+    it('diffs notes (update/create/delete, protecting system notes) and files', async () => {
+      vi.mocked(prisma.requeteEtape.findUnique)
+        .mockResolvedValueOnce({
+          id: 'step-1',
+          type: 'MANUAL',
+          statutId: 'A_FAIRE',
+          entiteId: 'e1',
+          notes: [
+            { id: 'keep', authorId: 'u' },
+            { id: 'remove', authorId: 'u' },
+            { id: 'system', authorId: null },
+          ],
+          uploadedFiles: [
+            { id: 'fA', canDelete: true, filePath: 'a.pdf' },
+            { id: 'fB', canDelete: true, filePath: 'b.pdf' },
+          ],
+          requete: { createdById: 'agent' },
+        } as never)
+        .mockResolvedValueOnce({ ...requeteEtape, id: 'step-1' });
+
+      const tx = makeTx();
+      vi.mocked(isUserOwner).mockResolvedValue(true);
+      vi.mocked(prisma.$transaction).mockImplementation((async (cb: (t: unknown) => unknown) => cb(tx)) as never);
+      vi.mocked(deleteFileFromMinio).mockResolvedValue();
+
+      await updateProcessingEtape(
+        'step-1',
+        'user-1',
+        {
+          nom: 'X',
+          statutId: 'A_FAIRE',
+          notes: [{ id: 'keep', texte: 'updated' }, { texte: 'new note' }],
+          fileIds: ['fA', 'fC'],
+        },
+        logger,
+      );
+
+      expect(tx.requeteEtape.update).toHaveBeenCalledTimes(1);
+      expect(tx.requeteEtapeNote.update).toHaveBeenCalledWith({ where: { id: 'keep' }, data: { texte: 'updated' } });
+      expect(tx.requeteEtapeNote.create).toHaveBeenCalledTimes(1);
+      expect(tx.requeteEtapeNote.delete).toHaveBeenCalledWith({ where: { id: 'remove' } });
+      expect(tx.requeteEtapeNote.delete).toHaveBeenCalledTimes(1);
+      expect(setEtapeFile).toHaveBeenCalledWith('step-1', ['fC'], 'e1', 'user-1', tx);
+      expect(tx.uploadedFile.deleteMany).toHaveBeenCalledWith({ where: { id: { in: ['fB'] } } });
+      expect(deleteFileFromMinio).toHaveBeenCalledWith('b.pdf');
+    });
+
+    it('automatic ACR: applies notes only, leaves fields and files untouched', async () => {
+      vi.mocked(prisma.requeteEtape.findUnique)
+        .mockResolvedValueOnce({
+          id: 'ack',
+          type: 'ACKNOWLEDGMENT',
+          statutId: 'FAIT',
+          entiteId: 'e1',
+          notes: [],
+          uploadedFiles: [{ id: 'ar', canDelete: false, filePath: 'ar.pdf' }],
+          requete: { createdById: null },
+        } as never)
+        .mockResolvedValueOnce({ ...requeteEtape, id: 'ack' });
+
+      const tx = makeTx();
+      vi.mocked(prisma.$transaction).mockImplementation((async (cb: (t: unknown) => unknown) => cb(tx)) as never);
+
+      await updateProcessingEtape(
+        'ack',
+        'user-1',
+        { nom: 'Changed', statutId: 'A_FAIRE', notes: [{ texte: 'note added' }], fileIds: [] },
+        logger,
+      );
+
+      expect(tx.requeteEtape.update).not.toHaveBeenCalled();
+      expect(tx.requeteEtapeNote.create).toHaveBeenCalledTimes(1);
+      expect(tx.uploadedFile.deleteMany).not.toHaveBeenCalled();
+      expect(tx.uploadedFile.updateMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -18,7 +18,7 @@ import {
   deleteRequeteEtape,
   EtapeNotEditableError,
   FilesNotOwnedError,
-  getEtapeEditability,
+  getEtapePermissions,
   getRequeteEtapeById,
   getRequeteEtapes,
   updateProcessingEtape,
@@ -860,45 +860,45 @@ describe('RequeteEtapes.service.ts', () => {
     });
   });
 
-  describe('getEtapeEditability', () => {
+  describe('getEtapePermissions', () => {
     it('MANUAL step is fully editable', () => {
-      expect(getEtapeEditability({ type: 'MANUAL', statutId: 'A_FAIRE', requete: { createdById: 'agent-1' } })).toEqual(
+      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'A_FAIRE', requete: { createdById: 'agent-1' } })).toEqual(
         {
           editable: true,
-          ackNotesOnly: false,
+          canOnlyEditNotes: false,
         },
       );
     });
 
     it('CLOTUREE step is not editable', () => {
-      expect(getEtapeEditability({ type: 'MANUAL', statutId: 'CLOTUREE', requete: { createdById: 'a' } })).toEqual({
+      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'CLOTUREE', requete: { createdById: 'a' } })).toEqual({
         editable: false,
-        ackNotesOnly: false,
+        canOnlyEditNotes: false,
       });
     });
 
     it('CREATION and REOPEN steps are not editable', () => {
-      expect(getEtapeEditability({ type: 'CREATION', statutId: 'FAIT', requete: { createdById: null } }).editable).toBe(
+      expect(getEtapePermissions({ type: 'CREATION', statutId: 'FAIT', requete: { createdById: null } }).editable).toBe(
         false,
       );
-      expect(getEtapeEditability({ type: 'REOPEN', statutId: 'FAIT', requete: { createdById: 'a' } }).editable).toBe(
+      expect(getEtapePermissions({ type: 'REOPEN', statutId: 'FAIT', requete: { createdById: 'a' } }).editable).toBe(
         false,
       );
     });
 
     it('automatic ACR (requete without createdById) is notes-only', () => {
-      expect(getEtapeEditability({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: null } })).toEqual(
+      expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: null } })).toEqual(
         {
           editable: true,
-          ackNotesOnly: true,
+          canOnlyEditNotes: true,
         },
       );
     });
 
     it('manual ACR (requete with createdById) is fully editable', () => {
       expect(
-        getEtapeEditability({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: 'agent-1' } }),
-      ).toEqual({ editable: true, ackNotesOnly: false });
+        getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: 'agent-1' } }),
+      ).toEqual({ editable: true, canOnlyEditNotes: false });
     });
   });
 
@@ -952,6 +952,12 @@ describe('RequeteEtapes.service.ts', () => {
       vi.mocked(prisma.requete.findUnique).mockResolvedValueOnce({ id: 'req-1' } as Requete);
       vi.mocked(prisma.requeteEntite.upsert).mockResolvedValueOnce({} as RequeteEntite);
       vi.mocked(isUserOwner).mockResolvedValue(false);
+
+      const tx = {
+        requeteEtape: { create: vi.fn().mockResolvedValue({ ...requeteEtape, id: 'new-step' }) },
+        requeteEtapeNote: { create: vi.fn() },
+      };
+      vi.mocked(prisma.$transaction).mockImplementation((async (cb: (t: unknown) => unknown) => cb(tx)) as never);
 
       await expect(
         createProcessingEtape('req-1', 'e1', 'user-1', { nom: 'X', notes: [], fileIds: ['not-mine'] }, logger),

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -7,9 +7,11 @@ import type { Prisma } from '../../libs/prisma.js';
 import { prisma, type RequeteEtape } from '../../libs/prisma.js';
 import { createChangeLog } from '../changelog/changelog.service.js';
 import { ChangeLogAction } from '../changelog/changelog.type.js';
+import { isUserOwner, setEtapeFile } from '../uploadedFiles/uploadedFiles.service.js';
 import type {
+  AddProcessingStepDto,
   GetRequeteEtapesQuery,
-  RequeteEtapeCreationDto,
+  UpdateProcessingStepDto,
   UpdateRequeteEtapeDateRealisationDto,
   UpdateRequeteEtapeNomDto,
   UpdateRequeteEtapeStatutDto,
@@ -153,53 +155,262 @@ export const createDefaultRequeteEtapes = async (
   return { etape1, etape2 };
 };
 
-export const addProcessingEtape = async (
+export const getEtapeEditability = (etape: {
+  type: string;
+  statutId: string | null;
+  requete: { createdById: string | null } | null;
+}): { editable: boolean; ackNotesOnly: boolean } => {
+  if (etape.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) return { editable: false, ackNotesOnly: false };
+  if (etape.type === REQUETE_ETAPE_TYPES.CREATION || etape.type === REQUETE_ETAPE_TYPES.REOPEN) {
+    return { editable: false, ackNotesOnly: false };
+  }
+  const ackNotesOnly = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && etape.requete?.createdById == null;
+  return { editable: true, ackNotesOnly };
+};
+
+export class EtapeNotEditableError extends Error {
+  code = 'ETAPE_NOT_EDITABLE' as const;
+}
+
+export class FilesNotOwnedError extends Error {
+  code = 'FILES_NOT_OWNED' as const;
+}
+
+const logNoteChangelog = async (
+  action: ChangeLogAction,
+  noteId: string,
+  before: Prisma.JsonObject | null,
+  after: Prisma.JsonObject | null,
+  changedById: string,
+  logger: Pick<PinoLogger, 'error'>,
+): Promise<void> => {
+  try {
+    await createChangeLog({ entity: 'RequeteEtapeNote', entityId: noteId, action, before, after, changedById });
+  } catch (err) {
+    logger.error({ err, noteId }, 'Failed to create changelog for note');
+  }
+};
+
+export const createProcessingEtape = async (
   requeteId: string,
   entiteId: string | null,
-  data: RequeteEtapeCreationDto,
-  userId?: string,
+  userId: string,
+  data: AddProcessingStepDto,
+  logger: PinoLogger,
 ) => {
   if (!entiteId) {
     return null;
   }
 
-  // First check if the requete exists
-  const requete = await prisma.requete.findUnique({
-    where: { id: requeteId },
-  });
-
+  const requete = await prisma.requete.findUnique({ where: { id: requeteId } });
   if (!requete) {
     return null;
   }
 
-  // Ensure RequeteEntite exists (create if not)
   await prisma.requeteEntite.upsert({
-    where: {
-      requeteId_entiteId: {
-        requeteId,
-        entiteId,
-      },
-    },
-    create: {
-      requeteId,
-      entiteId,
-      statutId: REQUETE_STATUT_TYPES.NOUVEAU,
-    },
+    where: { requeteId_entiteId: { requeteId, entiteId } },
+    create: { requeteId, entiteId, statutId: REQUETE_STATUT_TYPES.NOUVEAU },
     update: {},
   });
 
-  const etape = await prisma.requeteEtape.create({
-    data: {
-      requeteId,
-      entiteId,
-      nom: data.nom,
-      type: REQUETE_ETAPE_TYPES.MANUAL,
-      statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE,
-      createdById: userId,
-    },
+  const statutId = data.statutId ?? REQUETE_ETAPE_STATUT_TYPES.A_FAIRE;
+  const dateRealisation = statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
+
+  if (data.fileIds.length > 0 && !(await isUserOwner(userId, data.fileIds))) {
+    throw new FilesNotOwnedError('FILES_NOT_OWNED');
+  }
+
+  const createdNotes: { id: string; texte: string; authorId: string | null; requeteEtapeId: string }[] = [];
+
+  const etape = await prisma.$transaction(async (tx) => {
+    const etape = await tx.requeteEtape.create({
+      data: {
+        requeteId,
+        entiteId,
+        nom: data.nom,
+        type: REQUETE_ETAPE_TYPES.MANUAL,
+        statutId,
+        dateRealisation,
+        createdById: userId,
+      },
+    });
+
+    for (const note of data.notes) {
+      const created = await tx.requeteEtapeNote.create({
+        data: { authorId: userId, texte: note.texte, requeteEtapeId: etape.id },
+      });
+      createdNotes.push(created);
+    }
+
+    if (data.fileIds.length > 0) {
+      await setEtapeFile(etape.id, data.fileIds, entiteId, userId, tx);
+    }
+
+    return etape;
   });
 
+  await Promise.allSettled(
+    createdNotes.map((note) =>
+      logNoteChangelog(
+        ChangeLogAction.CREATED,
+        note.id,
+        null,
+        { id: note.id, texte: note.texte, authorId: note.authorId, requeteEtapeId: note.requeteEtapeId },
+        userId,
+        logger,
+      ),
+    ),
+  );
+
   return etape;
+};
+
+export const updateProcessingEtape = async (
+  stepId: string,
+  userId: string,
+  data: UpdateProcessingStepDto,
+  logger: PinoLogger,
+): Promise<RequeteEtape | null> => {
+  const etape = await prisma.requeteEtape.findUnique({
+    where: { id: stepId },
+    include: {
+      notes: { select: { id: true, authorId: true, texte: true } },
+      uploadedFiles: { select: { id: true, canDelete: true, filePath: true } },
+      requete: { select: { createdById: true } },
+    },
+  });
+  if (!etape) {
+    return null;
+  }
+
+  const { editable, ackNotesOnly } = getEtapeEditability(etape);
+  if (!editable) {
+    throw new EtapeNotEditableError('ETAPE_NOT_EDITABLE');
+  }
+
+  // Diff notes — only notes of THIS step and non system (authorId non null) are editable/deletable.
+  const editableNoteIds = new Set(etape.notes.filter((n) => n.authorId !== null).map((n) => n.id));
+  const existingNoteById = new Map(etape.notes.map((n) => [n.id, n]));
+  const sentNoteIds = new Set(data.notes.filter((n) => n.id).map((n) => n.id as string));
+  const notesToDelete = etape.notes.filter((n) => n.authorId !== null && !sentNoteIds.has(n.id));
+
+  // Diff files — only remove those removed AND deletable (canDelete) ; never lose anything else.
+  const currentFileIds = new Set(etape.uploadedFiles.map((f) => f.id));
+  const desiredFileIds = new Set(data.fileIds);
+  const fileIdsToAttach = data.fileIds.filter((id) => !currentFileIds.has(id));
+  const filesToRemove = etape.uploadedFiles.filter((f) => !desiredFileIds.has(f.id) && f.canDelete);
+
+  // User must own the files he attaches
+  if (!ackNotesOnly && fileIdsToAttach.length > 0 && !(await isUserOwner(userId, fileIdsToAttach))) {
+    throw new FilesNotOwnedError('FILES_NOT_OWNED');
+  }
+
+  const dateRealisation =
+    data.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
+
+  const noteChangelogs: {
+    action: ChangeLogAction;
+    id: string;
+    before: Prisma.JsonObject | null;
+    after: Prisma.JsonObject | null;
+  }[] = [];
+
+  await prisma.$transaction(async (tx) => {
+    if (!ackNotesOnly) {
+      await tx.requeteEtape.update({
+        where: { id: stepId },
+        data: { nom: data.nom, statutId: data.statutId, dateRealisation },
+      });
+    }
+
+    // The panel sends the full desired state of the notes:
+    // - note with an id that is editable (of this step, non system) -> update the text;
+    // - note with an id that is not editable (system / other entity) -> ignored (read-only);
+    // - note without an id -> create.
+    // Editable notes missing from the payload are deleted (notesToDelete, below).
+    for (const note of data.notes) {
+      if (note.id) {
+        if (editableNoteIds.has(note.id)) {
+          const before = existingNoteById.get(note.id);
+          await tx.requeteEtapeNote.update({ where: { id: note.id }, data: { texte: note.texte } });
+          if (before && before.texte !== note.texte) {
+            noteChangelogs.push({
+              action: ChangeLogAction.UPDATED,
+              id: note.id,
+              before: { texte: before.texte, authorId: before.authorId },
+              after: { texte: note.texte, authorId: before.authorId },
+            });
+          }
+        }
+      } else {
+        const created = await tx.requeteEtapeNote.create({
+          data: { authorId: userId, texte: note.texte, requeteEtapeId: stepId },
+        });
+        noteChangelogs.push({
+          action: ChangeLogAction.CREATED,
+          id: created.id,
+          before: null,
+          after: { id: created.id, texte: created.texte, authorId: created.authorId, requeteEtapeId: stepId },
+        });
+      }
+    }
+    for (const note of notesToDelete) {
+      await tx.requeteEtapeNote.delete({ where: { id: note.id } });
+      noteChangelogs.push({
+        action: ChangeLogAction.DELETED,
+        id: note.id,
+        before: { id: note.id, texte: note.texte, authorId: note.authorId },
+        after: null,
+      });
+    }
+
+    if (!ackNotesOnly) {
+      if (fileIdsToAttach.length > 0) {
+        await setEtapeFile(stepId, fileIdsToAttach, etape.entiteId, userId, tx);
+      }
+      if (filesToRemove.length > 0) {
+        await tx.uploadedFile.deleteMany({ where: { id: { in: filesToRemove.map((f) => f.id) } } });
+      }
+    }
+  });
+
+  await Promise.allSettled(
+    noteChangelogs.map((ev) => logNoteChangelog(ev.action, ev.id, ev.before, ev.after, userId, logger)),
+  );
+
+  if (!ackNotesOnly && filesToRemove.length > 0) {
+    await Promise.allSettled(
+      filesToRemove.map(async (f) => {
+        try {
+          await createChangeLog({
+            entity: 'UploadedFile',
+            entityId: f.id,
+            action: ChangeLogAction.DELETED,
+            before: { id: f.id, canDelete: f.canDelete, filePath: f.filePath } as Prisma.JsonObject,
+            after: null,
+            changedById: userId,
+          });
+        } catch (err) {
+          logger.error({ err, fileId: f.id }, 'Failed to create changelog for removed step file');
+        }
+      }),
+    );
+  }
+
+  // Delete physical files from MinIO after commit
+  if (!ackNotesOnly && filesToRemove.length > 0) {
+    await Promise.allSettled(
+      filesToRemove.map(async (f) => {
+        try {
+          await deleteFileFromMinio(f.filePath);
+        } catch (err) {
+          logger.error({ err, filePath: f.filePath }, 'Failed to delete MinIO file from step');
+        }
+      }),
+    );
+  }
+
+  return prisma.requeteEtape.findUnique({ where: { id: stepId } });
 };
 
 export const getRequeteEtapes = async (requeteId: string, entiteId: string | null, query: GetRequeteEtapesQuery) => {

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -155,17 +155,18 @@ export const createDefaultRequeteEtapes = async (
   return { etape1, etape2 };
 };
 
-export const getEtapeEditability = (etape: {
+export const getEtapePermissions = (etape: {
   type: string;
   statutId: string | null;
   requete: { createdById: string | null } | null;
-}): { editable: boolean; ackNotesOnly: boolean } => {
-  if (etape.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) return { editable: false, ackNotesOnly: false };
+}): { editable: boolean; canOnlyEditNotes: boolean } => {
+  if (etape.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) return { editable: false, canOnlyEditNotes: false };
   if (etape.type === REQUETE_ETAPE_TYPES.CREATION || etape.type === REQUETE_ETAPE_TYPES.REOPEN) {
-    return { editable: false, ackNotesOnly: false };
+    return { editable: false, canOnlyEditNotes: false };
   }
-  const ackNotesOnly = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && etape.requete?.createdById == null;
-  return { editable: true, ackNotesOnly };
+  // Automatic ACR = acknowledgment step on a request not created by an agent (createdById null).
+  const canOnlyEditNotes = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && etape.requete?.createdById == null;
+  return { editable: true, canOnlyEditNotes };
 };
 
 export class EtapeNotEditableError extends Error {
@@ -216,10 +217,6 @@ export const createProcessingEtape = async (
   const statutId = data.statutId ?? REQUETE_ETAPE_STATUT_TYPES.A_FAIRE;
   const dateRealisation = statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
 
-  if (data.fileIds.length > 0 && !(await isUserOwner(userId, data.fileIds))) {
-    throw new FilesNotOwnedError('FILES_NOT_OWNED');
-  }
-
   const createdNotes: { id: string; texte: string; authorId: string | null; requeteEtapeId: string }[] = [];
 
   const etape = await prisma.$transaction(async (tx) => {
@@ -243,6 +240,9 @@ export const createProcessingEtape = async (
     }
 
     if (data.fileIds.length > 0) {
+      if (!(await isUserOwner(userId, data.fileIds, tx))) {
+        throw new FilesNotOwnedError('FILES_NOT_OWNED');
+      }
       await setEtapeFile(etape.id, data.fileIds, entiteId, userId, tx);
     }
 
@@ -265,6 +265,119 @@ export const createProcessingEtape = async (
   return etape;
 };
 
+type EtapeNoteRow = { id: string; authorId: string | null; texte: string };
+type EtapeFileRow = { id: string; canDelete: boolean; filePath: string };
+type NoteChangelogEntry = {
+  action: ChangeLogAction;
+  id: string;
+  before: Prisma.JsonObject | null;
+  after: Prisma.JsonObject | null;
+};
+
+// Diff notes — only notes of THIS step and non system (authorId non null) are editable/deletable.
+const diffEtapeNotes = (existingNotes: EtapeNoteRow[], sentNotes: UpdateProcessingStepDto['notes']) => {
+  const editableNoteIds = new Set(existingNotes.filter((n) => n.authorId !== null).map((n) => n.id));
+  const existingNoteById = new Map<string, EtapeNoteRow>(existingNotes.map((n) => [n.id, n]));
+  const sentNoteIds = new Set(sentNotes.filter((n) => n.id).map((n) => n.id as string));
+  const notesToDelete = existingNotes.filter((n) => n.authorId !== null && !sentNoteIds.has(n.id));
+  return { editableNoteIds, existingNoteById, notesToDelete };
+};
+
+// Diff files — only remove those removed AND deletable (canDelete) ; never lose anything else.
+const diffEtapeFiles = (uploadedFiles: EtapeFileRow[], desiredFileIds: string[]) => {
+  const currentFileIds = new Set(uploadedFiles.map((f) => f.id));
+  const desired = new Set(desiredFileIds);
+  const fileIdsToAttach = desiredFileIds.filter((id) => !currentFileIds.has(id));
+  const filesToRemove = uploadedFiles.filter((f) => !desired.has(f.id) && f.canDelete);
+  return { fileIdsToAttach, filesToRemove };
+};
+
+// Applies the desired note state inside the transaction and returns the changelog entries to emit after commit.
+// The panel sends the full desired state of the notes:
+// - note with an id that is editable (of this step, non system) -> update the text;
+// - note with an id that is not editable (system / other entity) -> ignored (read-only);
+// - note without an id -> create.
+// Editable notes missing from the payload are deleted (notesToDelete).
+const applyEtapeNoteChanges = async (
+  tx: Prisma.TransactionClient,
+  stepId: string,
+  userId: string,
+  sentNotes: UpdateProcessingStepDto['notes'],
+  diff: ReturnType<typeof diffEtapeNotes>,
+): Promise<NoteChangelogEntry[]> => {
+  const changelogs: NoteChangelogEntry[] = [];
+  for (const note of sentNotes) {
+    if (note.id) {
+      if (diff.editableNoteIds.has(note.id)) {
+        const before = diff.existingNoteById.get(note.id);
+        await tx.requeteEtapeNote.update({ where: { id: note.id }, data: { texte: note.texte } });
+        if (before && before.texte !== note.texte) {
+          changelogs.push({
+            action: ChangeLogAction.UPDATED,
+            id: note.id,
+            before: { texte: before.texte, authorId: before.authorId },
+            after: { texte: note.texte, authorId: before.authorId },
+          });
+        }
+      }
+    } else {
+      const created = await tx.requeteEtapeNote.create({
+        data: { authorId: userId, texte: note.texte, requeteEtapeId: stepId },
+      });
+      changelogs.push({
+        action: ChangeLogAction.CREATED,
+        id: created.id,
+        before: null,
+        after: { id: created.id, texte: created.texte, authorId: created.authorId, requeteEtapeId: stepId },
+      });
+    }
+  }
+  for (const note of diff.notesToDelete) {
+    await tx.requeteEtapeNote.delete({ where: { id: note.id } });
+    changelogs.push({
+      action: ChangeLogAction.DELETED,
+      id: note.id,
+      before: { id: note.id, texte: note.texte, authorId: note.authorId },
+      after: null,
+    });
+  }
+  return changelogs;
+};
+
+const cleanupRemovedEtapeFiles = async (
+  filesToRemove: EtapeFileRow[],
+  userId: string,
+  logger: PinoLogger,
+): Promise<void> => {
+  await Promise.allSettled(
+    filesToRemove.map(async (f) => {
+      try {
+        await createChangeLog({
+          entity: 'UploadedFile',
+          entityId: f.id,
+          action: ChangeLogAction.DELETED,
+          before: { id: f.id, canDelete: f.canDelete, filePath: f.filePath } as Prisma.JsonObject,
+          after: null,
+          changedById: userId,
+        });
+      } catch (err) {
+        logger.error({ err, fileId: f.id }, 'Failed to create changelog for removed step file');
+      }
+    }),
+  );
+
+  // Delete physical files from MinIO after commit
+  await Promise.allSettled(
+    filesToRemove.map(async (f) => {
+      try {
+        await deleteFileFromMinio(f.filePath);
+      } catch (err) {
+        logger.error({ err, filePath: f.filePath }, 'Failed to delete MinIO file from step');
+      }
+    }),
+  );
+};
+
 export const updateProcessingEtape = async (
   stepId: string,
   userId: string,
@@ -283,89 +396,35 @@ export const updateProcessingEtape = async (
     return null;
   }
 
-  const { editable, ackNotesOnly } = getEtapeEditability(etape);
+  const { editable, canOnlyEditNotes } = getEtapePermissions(etape);
   if (!editable) {
     throw new EtapeNotEditableError('ETAPE_NOT_EDITABLE');
   }
 
-  // Diff notes — only notes of THIS step and non system (authorId non null) are editable/deletable.
-  const editableNoteIds = new Set(etape.notes.filter((n) => n.authorId !== null).map((n) => n.id));
-  const existingNoteById = new Map(etape.notes.map((n) => [n.id, n]));
-  const sentNoteIds = new Set(data.notes.filter((n) => n.id).map((n) => n.id as string));
-  const notesToDelete = etape.notes.filter((n) => n.authorId !== null && !sentNoteIds.has(n.id));
-
-  // Diff files — only remove those removed AND deletable (canDelete) ; never lose anything else.
-  const currentFileIds = new Set(etape.uploadedFiles.map((f) => f.id));
-  const desiredFileIds = new Set(data.fileIds);
-  const fileIdsToAttach = data.fileIds.filter((id) => !currentFileIds.has(id));
-  const filesToRemove = etape.uploadedFiles.filter((f) => !desiredFileIds.has(f.id) && f.canDelete);
-
-  // User must own the files he attaches
-  if (!ackNotesOnly && fileIdsToAttach.length > 0 && !(await isUserOwner(userId, fileIdsToAttach))) {
-    throw new FilesNotOwnedError('FILES_NOT_OWNED');
-  }
+  const notesDiff = diffEtapeNotes(etape.notes, data.notes);
+  const { fileIdsToAttach, filesToRemove } = diffEtapeFiles(etape.uploadedFiles, data.fileIds);
 
   const dateRealisation =
     data.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
 
-  const noteChangelogs: {
-    action: ChangeLogAction;
-    id: string;
-    before: Prisma.JsonObject | null;
-    after: Prisma.JsonObject | null;
-  }[] = [];
+  let noteChangelogs: NoteChangelogEntry[] = [];
 
   await prisma.$transaction(async (tx) => {
-    if (!ackNotesOnly) {
+    // canOnlyEditNotes (automatic ACR) only persists notes
+    if (!canOnlyEditNotes) {
       await tx.requeteEtape.update({
         where: { id: stepId },
         data: { nom: data.nom, statutId: data.statutId, dateRealisation },
       });
     }
 
-    // The panel sends the full desired state of the notes:
-    // - note with an id that is editable (of this step, non system) -> update the text;
-    // - note with an id that is not editable (system / other entity) -> ignored (read-only);
-    // - note without an id -> create.
-    // Editable notes missing from the payload are deleted (notesToDelete, below).
-    for (const note of data.notes) {
-      if (note.id) {
-        if (editableNoteIds.has(note.id)) {
-          const before = existingNoteById.get(note.id);
-          await tx.requeteEtapeNote.update({ where: { id: note.id }, data: { texte: note.texte } });
-          if (before && before.texte !== note.texte) {
-            noteChangelogs.push({
-              action: ChangeLogAction.UPDATED,
-              id: note.id,
-              before: { texte: before.texte, authorId: before.authorId },
-              after: { texte: note.texte, authorId: before.authorId },
-            });
-          }
-        }
-      } else {
-        const created = await tx.requeteEtapeNote.create({
-          data: { authorId: userId, texte: note.texte, requeteEtapeId: stepId },
-        });
-        noteChangelogs.push({
-          action: ChangeLogAction.CREATED,
-          id: created.id,
-          before: null,
-          after: { id: created.id, texte: created.texte, authorId: created.authorId, requeteEtapeId: stepId },
-        });
-      }
-    }
-    for (const note of notesToDelete) {
-      await tx.requeteEtapeNote.delete({ where: { id: note.id } });
-      noteChangelogs.push({
-        action: ChangeLogAction.DELETED,
-        id: note.id,
-        before: { id: note.id, texte: note.texte, authorId: note.authorId },
-        after: null,
-      });
-    }
+    noteChangelogs = await applyEtapeNoteChanges(tx, stepId, userId, data.notes, notesDiff);
 
-    if (!ackNotesOnly) {
+    if (!canOnlyEditNotes) {
       if (fileIdsToAttach.length > 0) {
+        if (!(await isUserOwner(userId, fileIdsToAttach, tx))) {
+          throw new FilesNotOwnedError('FILES_NOT_OWNED');
+        }
         await setEtapeFile(stepId, fileIdsToAttach, etape.entiteId, userId, tx);
       }
       if (filesToRemove.length > 0) {
@@ -378,36 +437,8 @@ export const updateProcessingEtape = async (
     noteChangelogs.map((ev) => logNoteChangelog(ev.action, ev.id, ev.before, ev.after, userId, logger)),
   );
 
-  if (!ackNotesOnly && filesToRemove.length > 0) {
-    await Promise.allSettled(
-      filesToRemove.map(async (f) => {
-        try {
-          await createChangeLog({
-            entity: 'UploadedFile',
-            entityId: f.id,
-            action: ChangeLogAction.DELETED,
-            before: { id: f.id, canDelete: f.canDelete, filePath: f.filePath } as Prisma.JsonObject,
-            after: null,
-            changedById: userId,
-          });
-        } catch (err) {
-          logger.error({ err, fileId: f.id }, 'Failed to create changelog for removed step file');
-        }
-      }),
-    );
-  }
-
-  // Delete physical files from MinIO after commit
-  if (!ackNotesOnly && filesToRemove.length > 0) {
-    await Promise.allSettled(
-      filesToRemove.map(async (f) => {
-        try {
-          await deleteFileFromMinio(f.filePath);
-        } catch (err) {
-          logger.error({ err, filePath: f.filePath }, 'Failed to delete MinIO file from step');
-        }
-      }),
-    );
+  if (!canOnlyEditNotes && filesToRemove.length > 0) {
+    await cleanupRemovedEtapeFiles(filesToRemove, userId, logger);
   }
 
   return prisma.requeteEtape.findUnique({ where: { id: stepId } });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.type.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.type.ts
@@ -1,6 +1,8 @@
 import type { z } from 'zod';
 import type {
+  AddProcessingStepBodySchema,
   GetRequeteEtapesQuerySchema,
+  UpdateProcessingStepBodySchema,
   UpdateRequeteEtapeDateRealisationSchema,
   UpdateRequeteEtapeNomSchema,
   UpdateRequeteEtapeStatutSchema,
@@ -9,6 +11,8 @@ import type {
 export type RequeteEtapeCreationDto = {
   nom: string;
 };
+export type AddProcessingStepDto = z.infer<typeof AddProcessingStepBodySchema>;
+export type UpdateProcessingStepDto = z.infer<typeof UpdateProcessingStepBodySchema>;
 export type GetRequeteEtapesQuery = z.infer<typeof GetRequeteEtapesQuerySchema>;
 export type UpdateRequeteEtapeStatutDto = z.infer<typeof UpdateRequeteEtapeStatutSchema>;
 

--- a/apps/backend/src/features/uploadedFiles/uploadedFiles.service.ts
+++ b/apps/backend/src/features/uploadedFiles/uploadedFiles.service.ts
@@ -168,6 +168,16 @@ export const setNoteFile = async (
   return updateFilesWithRelation(uploadedFileId, { requeteEtapeNoteId: noteId }, entiteId, changedById);
 };
 
+export const setEtapeFile = async (
+  requeteEtapeId: string,
+  uploadedFileId: UploadedFile['id'][],
+  entiteId: string | null = null,
+  changedById?: string,
+  tx?: Prisma.TransactionClient,
+) => {
+  return updateFilesWithRelation(uploadedFileId, { requeteEtapeId }, entiteId, changedById, tx);
+};
+
 export const setRequeteFile = async (
   requeteId: string,
   uploadedFileId: UploadedFile['id'][],

--- a/apps/backend/src/features/uploadedFiles/uploadedFiles.service.ts
+++ b/apps/backend/src/features/uploadedFiles/uploadedFiles.service.ts
@@ -85,8 +85,13 @@ export const createUploadedFile = async (
   });
 };
 
-export const isUserOwner = async (userId: string, uploadedFileIds: UploadedFile['id'][]): Promise<boolean> => {
-  const count = await prisma.uploadedFile.count({
+export const isUserOwner = async (
+  userId: string,
+  uploadedFileIds: UploadedFile['id'][],
+  tx?: Prisma.TransactionClient,
+): Promise<boolean> => {
+  const client = tx ?? prisma;
+  const count = await client.uploadedFile.count({
     where: {
       id: { in: uploadedFileIds },
       uploadedById: userId,


### PR DESCRIPTION
PR3 du refacto Étapes (SIRENA-635/636) : un **endpoint consolidé transactionnel** pour créer/modifier une étape complète (nom + statut + date + notes + fichiers) en un seul appel, au lieu de 3-4 appels séparés.

- `POST /:id/processing-steps` (étendu) et `PATCH /:id` (nouveau) : tout dans une transaction, rollback si échec partiel.
- Parité préservée : bascule requête `NOUVEAU → EN_COURS`, historisation par note/fichier, `canDelete` + MinIO, permissions niveau entité, verrous (clôture/création/ACR auto).
- Endpoints legacy conservés pour la transition (retrait plus tard). Périmètre backend uniquement, aucune migration.