### PR TITLE
feat(sirena-635): rework ACR + clôture, fichiers au niveau étape (PR-5)

### DIFF
--- a/apps/backend/src/features/declarants/declarants.notification.service.test.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.test.ts
@@ -3,9 +3,11 @@ import { RECEPTION_TYPE } from '@sirena/common/constants';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ACKNOWLEDGMENT_EMAIL_SUBJECT } from '../../config/tipimail.constant.js';
 import { sendTipimailEmail } from '../../libs/mail/tipimail.js';
+import { uploadFileToMinio } from '../../libs/minio.js';
 import { prisma } from '../../libs/prisma.js';
 import { createChangeLog } from '../changelog/changelog.service.js';
-import { sendDeclarantAcknowledgmentEmail } from './declarants.notification.service.js';
+import { createUploadedFile } from '../uploadedFiles/uploadedFiles.service.js';
+import { sendDeclarantAcknowledgmentEmail, sendManualAcknowledgmentEmail } from './declarants.notification.service.js';
 
 vi.mock('../../libs/prisma.js', () => ({
   prisma: {
@@ -14,6 +16,14 @@ vi.mock('../../libs/prisma.js', () => ({
     },
     entite: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    requeteEtape: {
+      updateMany: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    requeteEtapeNote: {
+      create: vi.fn(),
     },
   },
 }));
@@ -408,5 +418,62 @@ describe('sendDeclarantAcknowledgmentEmail()', () => {
     expect(call?.text).toContain('ARS Normandie');
     expect(call?.text).toContain('Adresse e-mail : contact@ars.fr');
     expect(call?.text).toContain('CD Calvados');
+  });
+});
+
+describe('sendManualAcknowledgmentEmail() — PDF attachment', () => {
+  const mockedRequeteEtape = vi.mocked(prisma.requeteEtape);
+  const mockedRequeteEtapeNote = vi.mocked(prisma.requeteEtapeNote);
+  const mockedEntiteFindUnique = vi.mocked(prisma.entite.findUnique);
+  const mockedUploadFileToMinio = vi.mocked(uploadFileToMinio);
+  const mockedCreateUploadedFile = vi.mocked(createUploadedFile);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedRequeteEtape.updateMany.mockResolvedValue({ count: 1 } as any);
+    mockedRequeteEtape.findFirst.mockResolvedValue({ id: 'etapeAck' } as any);
+
+    mockedPrismaRequete.findUnique.mockResolvedValue({
+      id: 'req1',
+      declarant: { identite: { email: 'john@example.com', prenom: 'John', nom: 'Doe' } },
+    } as any);
+    mockedEntiteFindUnique.mockResolvedValue({
+      id: 'ent1',
+      nomComplet: 'ARS Normandie',
+      email: '',
+      emailContactUsager: 'contact@ars.fr',
+      telContactUsager: '',
+      adresseContactUsager: '',
+      entiteMereId: null,
+    } as any);
+    mockedSendTipimailEmail.mockResolvedValue({ status: 'success' } as any);
+
+    mockedUploadFileToMinio.mockResolvedValue({
+      objectPath: 'acr/file123.pdf',
+      rollback: vi.fn(),
+      encryptionMetadata: null,
+    } as any);
+    mockedCreateUploadedFile.mockResolvedValue({ id: 'file123', fileName: 'AR_req1.pdf' } as any);
+  });
+
+  it('attaches the AR PDF directly to the étape with the sender as uploadedById and creates no system note', async () => {
+    await sendManualAcknowledgmentEmail({
+      etapeId: 'etapeAck',
+      requeteId: 'req1',
+      entiteId: 'ent1',
+      userId: 'user123',
+    });
+
+    expect(mockedCreateUploadedFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requeteEtapeId: 'etapeAck',
+        requeteEtapeNoteId: null,
+        uploadedById: 'user123',
+        canDelete: false,
+      }),
+    );
+
+    expect(mockedRequeteEtapeNote.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -139,11 +139,11 @@ async function attachEmailPdfToStep(
           ...(encryptionMetadata && { encryption: encryptionMetadata }),
         },
         requeteEtapeNoteId: null,
-        requeteEtapeId: null,
+        requeteEtapeId: etape.id,
         requeteId: null,
         faitSituationId: null,
         demarchesEngageesId: null,
-        uploadedById: null,
+        uploadedById: authorId ?? null,
         entiteId,
       });
 
@@ -164,7 +164,7 @@ async function attachEmailPdfToStep(
         'metadata',
         'entiteId',
         'uploadedById',
-        'requeteEtapeNoteId',
+        'requeteEtapeId',
         'requeteId',
         'faitSituationId',
         'demarchesEngageesId',
@@ -189,36 +189,6 @@ async function attachEmailPdfToStep(
             error: changelogError,
           },
           'Failed to create changelog entry for uploaded file',
-        );
-      }
-
-      const note = await prisma.requeteEtapeNote.create({
-        data: {
-          texte: `Email d'accusé de réception envoyé le ${emailInfo.sentDate.toLocaleString('fr-FR')}`,
-          authorId: authorId ?? null,
-          requeteEtapeId: etape.id,
-          uploadedFiles: {
-            connect: [{ id: uploadedFile.id }],
-          },
-        },
-      });
-
-      try {
-        await createChangeLog({
-          entity: 'RequeteEtapeNote',
-          entityId: note.id,
-          action: ChangeLogAction.CREATED,
-          before: null,
-          after: {
-            texte: note.texte,
-            authorId: note.authorId,
-          },
-          changedById: null, // System action
-        });
-      } catch (changelogError) {
-        logger.error(
-          { requeteId, entiteId, noteId: note.id, error: changelogError },
-          'Failed to create changelog entry for requete etape note',
         );
       }
 

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.test.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.test.ts
@@ -1552,6 +1552,8 @@ describe('requetesEntite.service', () => {
       };
 
       const createRequeteEtape = vi.fn().mockResolvedValue(mockEtape);
+      const noteCreate = vi.fn().mockResolvedValue(mockNote);
+      const fileUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
       transactionSpy.mockImplementation(async (cb) => {
         const mockTx = {
           ...prismaMock,
@@ -1560,7 +1562,7 @@ describe('requetesEntite.service', () => {
             create: createRequeteEtape,
           },
           requeteEtapeNote: {
-            create: vi.fn().mockResolvedValue(mockNote),
+            create: noteCreate,
           },
           requeteEntite: {
             ...prismaMock.requeteEntite,
@@ -1568,7 +1570,7 @@ describe('requetesEntite.service', () => {
           },
           uploadedFile: {
             ...prismaMock.uploadedFile,
-            updateMany: vi.fn().mockResolvedValue({ count: 2 }),
+            updateMany: fileUpdateMany,
           },
         } as typeof prismaMock;
         return cb(mockTx);
@@ -1584,6 +1586,13 @@ describe('requetesEntite.service', () => {
         ['fileid1', 'fileid2'],
       );
 
+      expect(noteCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ texte: 'Test precision' }) }),
+      );
+      expect(fileUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['fileid1', 'fileid2'] } },
+        data: { requeteEtapeId: 'etape123' },
+      });
       expect(result).toEqual({
         etapeId: 'etape123',
         closedAt: '2024-01-01T10:00:00.000Z',
@@ -1641,6 +1650,7 @@ describe('requetesEntite.service', () => {
         createdAt: new Date('2024-01-01T10:00:00Z'),
       };
 
+      const noteCreate = vi.fn().mockResolvedValue(mockNote);
       transactionSpy.mockImplementation(async (cb) => {
         const mockTx = {
           ...prismaMock,
@@ -1650,7 +1660,7 @@ describe('requetesEntite.service', () => {
           },
           requeteEtapeNote: {
             ...prismaMock.requeteEtapeNote,
-            create: vi.fn().mockResolvedValue(mockNote),
+            create: noteCreate,
           },
           requeteEntite: {
             ...prismaMock.requeteEntite,
@@ -1662,13 +1672,14 @@ describe('requetesEntite.service', () => {
 
       const result = await closeRequeteForEntite('req123', 'ent123', ['reason123'], 'user123', '2024-01-01');
 
+      expect(noteCreate).not.toHaveBeenCalled();
       expect(result).toEqual({
         etapeId: 'etape123',
         closedAt: '2024-01-01T10:00:00.000Z',
         clotureEffectiveDate: '2024-01-01',
-        noteId: 'note123',
+        noteId: null,
         etape: mockEtape,
-        note: mockNote,
+        note: null,
       });
 
       expect(createChangeLog).toHaveBeenCalledWith({
@@ -1901,6 +1912,8 @@ describe('requetesEntite.service', () => {
         createdAt: new Date('2024-01-01T10:00:00Z'),
       };
 
+      const noteCreate = vi.fn().mockResolvedValue(mockNote);
+      const fileUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
       transactionSpy.mockImplementation(async (cb) => {
         const mockTx = {
           ...prismaMock,
@@ -1909,7 +1922,7 @@ describe('requetesEntite.service', () => {
             create: vi.fn().mockResolvedValue(mockEtape),
           },
           requeteEtapeNote: {
-            create: vi.fn().mockResolvedValue(mockNote),
+            create: noteCreate,
           },
           requeteEntite: {
             ...prismaMock.requeteEntite,
@@ -1917,7 +1930,7 @@ describe('requetesEntite.service', () => {
           },
           uploadedFile: {
             ...prismaMock.uploadedFile,
-            updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+            updateMany: fileUpdateMany,
           },
         } as typeof prismaMock;
         return cb(mockTx);
@@ -1933,13 +1946,18 @@ describe('requetesEntite.service', () => {
         ['fileid1'],
       );
 
+      expect(noteCreate).not.toHaveBeenCalled();
+      expect(fileUpdateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['fileid1'] } },
+        data: { requeteEtapeId: 'etape123' },
+      });
       expect(result).toEqual({
         etapeId: 'etape123',
         closedAt: '2024-01-01T10:00:00.000Z',
         clotureEffectiveDate: '2024-01-01',
-        noteId: 'note123',
+        noteId: null,
         etape: mockEtape,
-        note: mockNote,
+        note: null,
       });
 
       expect(createChangeLog).toHaveBeenCalledWith({
@@ -3299,6 +3317,48 @@ describe('requetesEntite.service', () => {
       expect(listSpy).toHaveBeenCalledWith(['AR_2026-06-RS9.pdf']);
       // The genuine user note is still rendered.
       expect(paragraphArgs).toContain("J'ai envoyé l'AR because...");
+    });
+
+    it('renders étape-level files (new ACR model without auto-note)', async () => {
+      const listSpy = vi.spyOn(RequetePdfBuilder.prototype, 'list');
+      vi.spyOn(RequetePdfBuilder.prototype, 'toBuffer').mockResolvedValue(Buffer.from('%PDF-test'));
+
+      const author = { prenom: 'Delphine', nom: 'TEST' };
+
+      vi.mocked(prisma.requeteEntite.findFirst).mockResolvedValueOnce({
+        ...mockRequeteEntite,
+        statut: { id: 'EN_COURS', label: 'En cours' },
+        priorite: null,
+        requete: {
+          ...mockRequeteEntite.requete,
+          receptionType: null,
+          provenance: null,
+          createdBy: author,
+          declarant: null,
+          participant: null,
+          fichiersRequeteOriginale: [],
+          situations: [],
+        },
+        requeteEtape: [
+          {
+            id: 'etapeAck',
+            type: REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT,
+            statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT,
+            statut: { id: 'FAIT', label: 'Fait' },
+            clotureReason: [],
+            createdBy: null,
+            nom: "Envoi de l'accusé de réception",
+            createdAt: new Date('2026-06-12'),
+            updatedAt: new Date('2026-06-15'),
+            uploadedFiles: [{ fileName: 'AR_2026-06-RS9.pdf', metadata: null }],
+            notes: [],
+          },
+        ],
+      } as unknown as Awaited<ReturnType<typeof prisma.requeteEntite.findFirst>>);
+
+      await generateRequetePdfBuffer('req123', 'ent123');
+
+      expect(listSpy).toHaveBeenCalledWith(['AR_2026-06-RS9.pdf']);
     });
   });
 

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -2431,6 +2431,13 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
   if (etapes.length > 0) {
     pdf.section('Étapes de traitement');
 
+    const addFileNames = (files: Pick<UploadedFile, 'fileName' | 'metadata'>[], names: Set<string>) => {
+      for (const file of files) {
+        const name = getOriginalFileName(file);
+        if (name) names.add(name);
+      }
+    };
+
     for (const etape of etapes) {
       const etapeTitle = getEtapePdfTitle(
         etape.type as RequeteEtapeType,
@@ -2470,16 +2477,8 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
       const displayNotes = sendNote ? etapeNotes.filter((note) => note.id !== sendNote.id) : etapeNotes;
 
       const etapeFileNames = new Set<string>();
-      const etapeFiles = (etape.uploadedFiles ?? [])
-        .map((f) => getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]))
-        .filter(Boolean);
-      for (const name of etapeFiles) etapeFileNames.add(name);
-      if (sendNote) {
-        for (const f of sendNote.uploadedFiles ?? []) {
-          const name = getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]);
-          if (name) etapeFileNames.add(name);
-        }
-      }
+      addFileNames(etape.uploadedFiles ?? [], etapeFileNames);
+      if (sendNote) addFileNames(sendNote.uploadedFiles ?? [], etapeFileNames);
       if (etapeFileNames.size > 0) {
         pdf.paragraph('Pièces jointes :', { bold: true });
         pdf.list([...etapeFileNames]);
@@ -2494,7 +2493,7 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
         if (note.texte) pdf.paragraph(note.texte);
 
         const noteFiles = (note.uploadedFiles ?? [])
-          .map((f) => getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]))
+          .map((f) => getOriginalFileName(f))
           .filter((name): name is string => Boolean(name) && !etapeFileNames.has(name));
         if (noteFiles.length > 0) {
           pdf.paragraph('Pièces jointes :', { bold: true });

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -1716,15 +1716,16 @@ export const closeRequeteForEntite = async (
       },
     });
 
-    const note = await tx.requeteEtapeNote.create({
-      data: {
-        requeteEtapeId: etape.id,
-        texte: precision?.trim() || '',
-        authorId,
-      },
-    });
-
-    const noteId = note.id;
+    const trimmedPrecision = precision?.trim() || '';
+    const note = trimmedPrecision
+      ? await tx.requeteEtapeNote.create({
+          data: {
+            requeteEtapeId: etape.id,
+            texte: trimmedPrecision,
+            authorId,
+          },
+        })
+      : null;
 
     if (fileIds && fileIds.length > 0) {
       await tx.uploadedFile.updateMany({
@@ -1732,7 +1733,7 @@ export const closeRequeteForEntite = async (
           id: { in: fileIds },
         },
         data: {
-          requeteEtapeNoteId: noteId,
+          requeteEtapeId: etape.id,
         },
       });
     }
@@ -1750,7 +1751,7 @@ export const closeRequeteForEntite = async (
       etapeId: etape.id,
       closedAt: etape.createdAt.toISOString(),
       clotureEffectiveDate,
-      noteId,
+      noteId: note?.id ?? null,
       etape,
       note,
     };
@@ -1773,21 +1774,22 @@ export const closeRequeteForEntite = async (
     changedById: authorId,
   });
 
-  // Create changelogs for the created step and note
-  await createRequeteEtapeNoteChangelog(
-    result.noteId,
-    ChangeLogAction.CREATED,
-    null,
-    {
-      id: result.note.id,
-      texte: result.note.texte,
-      authorId: result.note.authorId,
-      requeteEtapeId: result.note.requeteEtapeId,
-      clotureReasonIds: uniqueReasonIds,
-      createdAt: result.note.createdAt.toISOString(),
-    } as Prisma.JsonObject,
-    authorId,
-  );
+  if (result.note) {
+    await createRequeteEtapeNoteChangelog(
+      result.note.id,
+      ChangeLogAction.CREATED,
+      null,
+      {
+        id: result.note.id,
+        texte: result.note.texte,
+        authorId: result.note.authorId,
+        requeteEtapeId: result.note.requeteEtapeId,
+        clotureReasonIds: uniqueReasonIds,
+        createdAt: result.note.createdAt.toISOString(),
+      } as Prisma.JsonObject,
+      authorId,
+    );
+  }
 
   // Create changelogs for the uploaded files if any
   if (fileIds && fileIds.length > 0) {
@@ -1802,11 +1804,11 @@ export const closeRequeteForEntite = async (
         file.id,
         ChangeLogAction.UPDATED,
         {
-          requeteEtapeNoteId: null,
+          requeteEtapeId: null,
           metadata: file.metadata,
         } as Prisma.JsonObject,
         {
-          requeteEtapeNoteId: result.noteId,
+          requeteEtapeId: result.etapeId,
           metadata: file.metadata,
         } as Prisma.JsonObject,
         authorId,
@@ -2132,6 +2134,9 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
           statut: true,
           clotureReason: true,
           createdBy: { select: { prenom: true, nom: true } },
+          uploadedFiles: {
+            select: { fileName: true, metadata: true },
+          },
           notes: {
             orderBy: { createdAt: 'asc' },
             include: {
@@ -2457,8 +2462,6 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
         pdf.field('Motif(s) de clôture', etape.clotureReason.map((r) => r.label).join(', '));
       }
 
-      // The acknowledgment email auto-generates a note ("Email d'accusé de réception envoyé le ...").
-      // don't render it as a note, but keep its file at the étape level.
       const etapeNotes = etape.notes ?? [];
       const sendNote =
         etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT
@@ -2466,14 +2469,20 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
           : undefined;
       const displayNotes = sendNote ? etapeNotes.filter((note) => note.id !== sendNote.id) : etapeNotes;
 
+      const etapeFileNames = new Set<string>();
+      const etapeFiles = (etape.uploadedFiles ?? [])
+        .map((f) => getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]))
+        .filter(Boolean);
+      for (const name of etapeFiles) etapeFileNames.add(name);
       if (sendNote) {
-        const acknowledgmentFiles = (sendNote.uploadedFiles ?? [])
-          .map((f) => getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]))
-          .filter(Boolean);
-        if (acknowledgmentFiles.length > 0) {
-          pdf.paragraph('Pièces jointes :', { bold: true });
-          pdf.list(acknowledgmentFiles);
+        for (const f of sendNote.uploadedFiles ?? []) {
+          const name = getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]);
+          if (name) etapeFileNames.add(name);
         }
+      }
+      if (etapeFileNames.size > 0) {
+        pdf.paragraph('Pièces jointes :', { bold: true });
+        pdf.list([...etapeFileNames]);
       }
 
       for (const note of displayNotes) {
@@ -2486,7 +2495,7 @@ export const generateRequetePdfBuffer = async (requeteId: string, entiteId: stri
 
         const noteFiles = (note.uploadedFiles ?? [])
           .map((f) => getOriginalFileName(f as Parameters<typeof getOriginalFileName>[0]))
-          .filter(Boolean);
+          .filter((name): name is string => Boolean(name) && !etapeFileNames.has(name));
         if (noteFiles.length > 0) {
           pdf.paragraph('Pièces jointes :', { bold: true });
           pdf.list(noteFiles);


### PR DESCRIPTION
## PR5 — Rework système ACR + clôture (fichiers au niveau étape)

Supprime le mécanisme de « note fantôme » : les pièces jointes vivent désormais au niveau de l'étape (`requeteEtapeId`).

### Changements
- **ACR** (`attachEmailPdfToStep`) : plus de note système. Le PDF est rattaché directement à l'étape, avec `uploadedById` = expéditeur (agent en manuel, `null` en auto). `canDelete:false` conservé.
- **Clôture** (`closeRequeteForEntite`) : note créée uniquement si précision non vide ; fichiers rattachés à l'étape au lieu de la note. Changelogs conditionnés en conséquence.
- **Export PDF** : rend les PJ niveau étape (nouveau modèle)

