### PR TITLE
PR6 — Panneau unique de création/édition d'étape (front)

### DIFF
--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.schema.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.schema.ts
@@ -13,7 +13,7 @@ export const RequeteEtapeSchema = z.object({
     REQUETE_ETAPE_TYPES.MANUAL,
   ]),
   estPartagee: z.boolean(),
-  statutId: z.string(),
+  statutId: z.string().nullable(),
   dateRealisation: z.coerce.date().nullable(),
   requeteId: z.string(),
   entiteId: z.string(),
@@ -103,7 +103,7 @@ const requireDateWhenFait = (data: { statutId?: string | null; dateRealisation?:
 export const AddProcessingStepBodySchema = z
   .object({
     nom: etapeNomSchema,
-    statutId: etapeStatutEnum.optional(),
+    statutId: etapeStatutEnum.nullable().optional(),
     dateRealisation: z.coerce.date().optional(),
     notes: z
       .array(z.object({ texte: noteTexteSchema }))
@@ -116,7 +116,7 @@ export const AddProcessingStepBodySchema = z
 export const UpdateProcessingStepBodySchema = z
   .object({
     nom: etapeNomSchema,
-    statutId: etapeStatutEnum,
+    statutId: etapeStatutEnum.nullable().optional(),
     dateRealisation: z.coerce.date().optional(),
 
     notes: z.array(z.object({ id: z.string().optional(), texte: noteTexteSchema })).default([]),

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -954,11 +954,19 @@ describe('RequeteEtapes.service.ts', () => {
           canOnlyEditNotes: true,
         },
       );
+      // even before being marked FAIT, an automatic ACR stays notes-only
+      expect(
+        getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'A_FAIRE', requete: { createdById: null } }),
+      ).toEqual({ editable: true, canOnlyEditNotes: true });
     });
 
     it('manual ACR (requete with createdById) is fully editable', () => {
+      // a manually-sent ACR is not locked: an agent can still edit status/date/files
       expect(
         getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: 'agent-1' } }),
+      ).toEqual({ editable: true, canOnlyEditNotes: false });
+      expect(
+        getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'A_FAIRE', requete: { createdById: 'agent-1' } }),
       ).toEqual({ editable: true, canOnlyEditNotes: false });
     });
   });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -165,7 +165,8 @@ export const getEtapePermissions = (etape: {
   if (etape.type === REQUETE_ETAPE_TYPES.CREATION || etape.type === REQUETE_ETAPE_TYPES.REOPEN) {
     return { editable: false, canOnlyEditNotes: false };
   }
-  // Automatic ACR = acknowledgment step on a request not created by an agent (createdById null).
+  // Spec: only an ACR sent automatically is locked (status + uploaded files), notes always editable.
+  // Automatic = request not created by an agent (createdById null) ; a manual ACR stays fully editable.
   const canOnlyEditNotes = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && etape.requete?.createdById == null;
   return { editable: true, canOnlyEditNotes };
 };
@@ -215,7 +216,7 @@ export const createProcessingEtape = async (
     update: {},
   });
 
-  const statutId = data.statutId ?? REQUETE_ETAPE_STATUT_TYPES.A_FAIRE;
+  const statutId = data.statutId ?? null;
   const dateRealisation = statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
 
   const createdNotes: { id: string; texte: string; authorId: string | null; requeteEtapeId: string }[] = [];
@@ -405,8 +406,8 @@ export const updateProcessingEtape = async (
   const notesDiff = diffEtapeNotes(etape.notes, data.notes);
   const { fileIdsToAttach, filesToRemove } = diffEtapeFiles(etape.uploadedFiles, data.fileIds);
 
-  const dateRealisation =
-    data.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
+  const statutId = data.statutId ?? null;
+  const dateRealisation = statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT ? (data.dateRealisation ?? new Date()) : null;
 
   let noteChangelogs: NoteChangelogEntry[] = [];
 
@@ -415,7 +416,7 @@ export const updateProcessingEtape = async (
     if (!canOnlyEditNotes) {
       await tx.requeteEtape.update({
         where: { id: stepId },
-        data: { nom: data.nom, statutId: data.statutId, dateRealisation },
+        data: { nom: data.nom, statutId, dateRealisation },
       });
     }
 

--- a/apps/frontend/src/components/requestId/processing.tsx
+++ b/apps/frontend/src/components/requestId/processing.tsx
@@ -2,24 +2,21 @@ import { Alert } from '@codegouvfr/react-dsfr/Alert';
 import { Button } from '@codegouvfr/react-dsfr/Button';
 import { REQUETE_ETAPE_STATUT_TYPES, REQUETE_ETAPE_TYPES, REQUETE_STATUT_TYPES } from '@sirena/common/constants';
 import { useNavigate } from '@tanstack/react-router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { EntiteTypeBadge } from '@/components/common/EntiteTypeBadge';
 import { QueryStateHandler } from '@/components/queryStateHandler/queryStateHandler';
-import { CreateStep } from '@/components/requestId/processing/createStep';
 import { Step } from '@/components/requestId/processing/Step';
 import { useProcessingSteps } from '@/hooks/queries/processingSteps.hook';
 import { type useRequeteDetails, useRequeteOtherEntitiesAffected } from '@/hooks/queries/useRequeteDetails';
 import { useCanEdit } from '@/hooks/useCanEdit';
 import styles from '@/routes/_auth/_user/request.$requestId.module.css';
 import { CloseRequeteModal, type CloseRequeteModalRef } from './processing/CloseRequeteModal';
-import { CreateNoteDrawer, type CreateNoteDrawerRef } from './processing/CreateNoteDrawer';
-import { EditNoteDrawer, type EditNoteDrawerRef } from './processing/EditNoteDrawer';
 import { ReopenRequeteModal, type ReopenRequeteModalRef } from './processing/ReopenRequeteModal';
 import { SendAcknowledgmentDrawer, type SendAcknowledgmentDrawerRef } from './processing/SendAcknowledgmentDrawer';
+import { StepFormPanel, type StepFormPanelRef } from './processing/StepFormPanel';
 import { OtherEntitiesAffected } from './sections/OtherEntitesAffected';
 
 type StepType = NonNullable<ReturnType<typeof useProcessingSteps>['data']>['data'][number];
-type NoteData = Parameters<EditNoteDrawerRef['openDrawer']>[1];
 
 interface ProcessingProps {
   requestId?: string;
@@ -28,9 +25,7 @@ interface ProcessingProps {
 
 export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
   const navigate = useNavigate();
-  const [isAddingStep, setIsAddingStep] = useState(false);
-  const createNoteDrawerRef = useRef<CreateNoteDrawerRef>(null);
-  const editNoteDrawerRef = useRef<EditNoteDrawerRef>(null);
+  const stepFormPanelRef = useRef<StepFormPanelRef>(null);
   const sendAcknowledgmentDrawerRef = useRef<SendAcknowledgmentDrawerRef>(null);
   const closeRequeteModalRef = useRef<CloseRequeteModalRef>(null);
   const closeRequeteButtonRef = useRef<HTMLButtonElement>(null);
@@ -56,12 +51,7 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
   }, [queryProcessingSteps.error, navigate, requestId]);
 
   const handleOpenEdit = (step: StepType) => {
-    editNoteDrawerRef.current?.closeDrawer();
-    createNoteDrawerRef.current?.openDrawer(step);
-  };
-  const handleOpenEditNote = (step: StepType, noteData: NoteData) => {
-    createNoteDrawerRef.current?.closeDrawer();
-    editNoteDrawerRef.current?.openDrawer(step, noteData);
+    stepFormPanelRef.current?.openEdit(step);
   };
   const handleCloseRequete = () => closeRequeteModalRef.current?.openModal();
   const handleReopenRequete = () => reopenRequeteModalRef.current?.openModal();
@@ -70,26 +60,11 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
     <>
       <div className={styles['timeline-container']}>
         <div className={styles['timeline-line']} />
-        <CreateStep requestId={requestId} isAddingStep={isAddingStep} setIsAddingStep={setIsAddingStep} />
         <QueryStateHandler query={queryProcessingSteps}>
           {({ data }) => {
-            const isDematSocialRequest = !!requestQuery.data?.requete?.dematSocialId;
             const isManualRequest = !!requestQuery.data?.requete?.createdById;
 
-            return data.data.map((step, index: number) => {
-              const isAutomaticallyUpdated =
-                isDematSocialRequest &&
-                step.createdBy === null &&
-                step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT &&
-                step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
-              const hasAcknowledgmentEmailSent =
-                step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&
-                step.notes.some((note) => note.texte?.startsWith("Email d'accusé de réception envoyé le"));
-              const isDisabled =
-                index === data.data.length - 1 ||
-                step.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ||
-                isAutomaticallyUpdated ||
-                (hasAcknowledgmentEmailSent && step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT);
+            return data.data.map((step) => {
               const isAcknowledgmentSendable =
                 isManualRequest &&
                 step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT &&
@@ -99,21 +74,18 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                   key={step.id}
                   requestId={requestId}
                   {...step}
-                  disabled={isDisabled}
                   isAcknowledgmentSendable={isAcknowledgmentSendable}
                   onSendAcknowledgment={
                     isAcknowledgmentSendable ? () => sendAcknowledgmentDrawerRef.current?.openDrawer(step) : undefined
                   }
                   openEdit={handleOpenEdit}
-                  openEditNote={handleOpenEditNote}
                 />
               );
             });
           }}
         </QueryStateHandler>
       </div>
-      <CreateNoteDrawer ref={createNoteDrawerRef} />
-      <EditNoteDrawer ref={editNoteDrawerRef} />
+      <StepFormPanel ref={stepFormPanelRef} requestId={requestId} />
       <SendAcknowledgmentDrawer ref={sendAcknowledgmentDrawerRef} />
       <CloseRequeteModal ref={closeRequeteModalRef} requestId={requestId} triggerButtonRef={closeRequeteButtonRef} />
       <ReopenRequeteModal ref={reopenRequeteModalRef} requestId={requestId} triggerButtonRef={reopenRequeteButtonRef} />
@@ -184,8 +156,7 @@ export const Processing = ({ requestId, requestQuery }: ProcessingProps) => {
                       priority="secondary"
                       className="fr-mr-2w"
                       size="small"
-                      onClick={() => setIsAddingStep(true)}
-                      disabled={isAddingStep}
+                      onClick={() => stepFormPanelRef.current?.openCreate()}
                     >
                       Ajouter une étape
                     </Button>

--- a/apps/frontend/src/components/requestId/processing/Step.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.test.tsx
@@ -23,19 +23,6 @@ vi.mock('@sirena/ui', async (importOriginal) => {
   };
 });
 
-vi.mock('@/components/common/statusMenu', () => ({
-  StatusMenu: () => null,
-}));
-
-vi.mock('@/hooks/mutations/updateProcessingStep.hook', () => ({
-  useDeleteProcessingStep: () => ({ mutate: vi.fn(), isPending: false }),
-  useUpdateProcessingStepStatus: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-
-vi.mock('@/hooks/mutations/updateProcessingStepName.hook', () => ({
-  useUpdateProcessingStepName: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-
 vi.mock('@/hooks/mutations/updateUploadedFiles.hook', () => ({
   useDeleteUploadedFile: () => ({ mutate: vi.fn(), isPending: false }),
 }));
@@ -59,7 +46,7 @@ describe('Step', () => {
       requeteId: 'REQ-354',
       entiteId: 'ENTITE-1',
       id: 'step-1',
-      nom: 'Clôture de la requête',
+      nom: '',
       type: REQUETE_ETAPE_TYPES.MANUAL,
       statutId: REQUETE_ETAPE_STATUT_TYPES.CLOTUREE,
       dateRealisation: null,
@@ -67,6 +54,7 @@ describe('Step', () => {
       updatedAt: '2024-05-20T12:00:00.000Z',
       clotureEffectiveDate: '2024-05-18',
       createdBy: { prenom: 'camille', nom: 'dupont' },
+      dateRealisation: null,
       notes: [],
       uploadedFiles: [],
       editable: false,
@@ -74,6 +62,7 @@ describe('Step', () => {
       requete: {
         createdById: null,
         dematSocialId: null,
+        createdById: null,
         thirdPartyAccountId: null,
         createdBy: null,
       },

--- a/apps/frontend/src/components/requestId/processing/Step.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.test.tsx
@@ -54,7 +54,6 @@ describe('Step', () => {
       updatedAt: '2024-05-20T12:00:00.000Z',
       clotureEffectiveDate: '2024-05-18',
       createdBy: { prenom: 'camille', nom: 'dupont' },
-      dateRealisation: null,
       notes: [],
       uploadedFiles: [],
       editable: false,
@@ -62,7 +61,6 @@ describe('Step', () => {
       requete: {
         createdById: null,
         dematSocialId: null,
-        createdById: null,
         thirdPartyAccountId: null,
         createdBy: null,
       },

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -129,7 +129,10 @@ const getStepSubtitle = (
     <>
       {formatStepCreationInfo(createdBy, createdAt)}
       {statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT && dateRealisation ? (
-        <> • Fait le {formatDate(dateRealisation)}</>
+        <>
+          {' '}
+          <span aria-hidden="true">•</span> Fait le {formatDate(dateRealisation)}
+        </>
       ) : null}
     </>
   );
@@ -223,9 +226,9 @@ const StepComponent = ({
             </div>
             {showAFaireBadge && (
               <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-                <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--info">
+                <p className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--info">
                   {requeteEtapeStatutType.A_FAIRE}
-                </span>
+                </p>
               </div>
             )}
           </div>

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -1,31 +1,24 @@
 import { fr } from '@codegouvfr/react-dsfr';
 import { Button } from '@codegouvfr/react-dsfr/Button';
-import { Input } from '@codegouvfr/react-dsfr/Input';
 import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import {
   REQUETE_ETAPE_STATUT_TYPES,
   REQUETE_ETAPE_TYPES,
-  type RequeteEtapeStatutType,
   ROLES,
+  requeteEtapeStatutType,
 } from '@sirena/common/constants';
 import { Toast } from '@sirena/ui';
 
 import { clsx } from 'clsx';
 import { memo, useMemo, useRef, useState } from 'react';
-import { ButtonLink } from '@/components/common/ButtonLink';
 import { FileDownloadLink } from '@/components/common/FileDownloadLink';
-import { StatusMenu } from '@/components/common/statusMenu';
 import { capitalizeFirst } from '@/components/requestId/sections/helpers';
-import { useDeleteProcessingStep, useUpdateProcessingStepStatus } from '@/hooks/mutations/updateProcessingStep.hook';
-import { useUpdateProcessingStepName } from '@/hooks/mutations/updateProcessingStepName.hook';
 import { useDeleteUploadedFile } from '@/hooks/mutations/updateUploadedFiles.hook';
 import type { useProcessingSteps } from '@/hooks/queries/processingSteps.hook';
 import { useCanEdit } from '@/hooks/useCanEdit';
 import { useModalFocusRestore } from '@/hooks/useModalFocusRestore';
 import styles from '@/routes/_auth/_user/request.$requestId.module.css';
-import { UpdateProcessingStepNameSchema } from '@/schemas/processingSteps.schema';
 import { useUserStore } from '@/stores/userStore';
-import { requeteEtapeStatutBadges } from '@/utils/requeteStatutBadge.constant';
 import { AddFilesClotureDrawer, type AddFilesClotureDrawerRef } from './AddFilesClotureDrawer';
 import { StepNote } from './StepNote';
 
@@ -33,20 +26,12 @@ type StepType = NonNullable<ReturnType<typeof useProcessingSteps>['data']>['data
 
 type StepProps = StepType & {
   requestId: string;
-  disabled?: boolean;
   isAcknowledgmentSendable?: boolean;
   onSendAcknowledgment?: () => void;
   openEdit?(step: StepType): void;
-  openEditNote?(
-    step: StepType,
-    noteData: {
-      content: string;
-      files: { id: string; size: number; originalName: string }[];
-    },
-  ): void;
 };
 
-const formatDate = (dateStr: string) =>
+const formatDate = (dateStr: string | Date) =>
   new Date(dateStr).toLocaleDateString('fr-FR', {
     day: '2-digit',
     month: '2-digit',
@@ -91,6 +76,7 @@ const getStepSubtitle = (
   notes: StepType['notes'],
   requete: StepType['requete'],
   clotureEffectiveDate?: string | null,
+  dateRealisation?: string | Date | null,
 ): React.ReactNode => {
   if (statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) {
     const agent = createdBy ?? notes[0]?.author;
@@ -139,7 +125,14 @@ const getStepSubtitle = (
     }
     return `Ajouté automatiquement le ${formatDate(createdAt)}`;
   }
-  return formatStepCreationInfo(createdBy, createdAt);
+  return (
+    <>
+      {formatStepCreationInfo(createdBy, createdAt)}
+      {statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT && dateRealisation ? (
+        <> • Fait le {formatDate(dateRealisation)}</>
+      ) : null}
+    </>
+  );
 };
 
 const StepComponent = ({
@@ -149,21 +142,15 @@ const StepComponent = ({
   createdAt,
   updatedAt,
   statutId,
-  disabled,
   isAcknowledgmentSendable,
   onSendAcknowledgment,
   openEdit,
-  openEditNote,
   notes,
   id,
   requete,
   clotureEffectiveDate,
   ...rest
 }: StepProps) => {
-  const deleteStepModal = createModal({
-    id: `delete-step-modal-${id}`,
-    isOpenedByDefault: false,
-  });
   const deleteClotureFileModal = useMemo(
     () =>
       createModal({
@@ -178,100 +165,30 @@ const StepComponent = ({
     name: string;
   } | null>(null);
   const [deletedFileIds, setDeletedFileIds] = useState<Set<string>>(new Set());
-  const updateStatusMutation = useUpdateProcessingStepStatus(requestId);
-  const updateStepNameMutation = useUpdateProcessingStepName(requestId);
-  const deleteStepMutation = useDeleteProcessingStep(requestId);
   const deleteFileMutation = useDeleteUploadedFile({ requeteId: requestId });
   const toastManager = Toast.useToastManager();
-  const { registerTrigger } = useModalFocusRestore([deleteStepModal.id, deleteClotureFileModal.id]);
+  useModalFocusRestore([deleteClotureFileModal.id]);
   const addFilesClotureDrawerRef = useRef<AddFilesClotureDrawerRef>(null);
 
-  const [isEditing, setIsEditing] = useState(false);
-  const [editStepName, setEditStepName] = useState(nom ?? '');
-  const [editError, setEditError] = useState<string | null>(null);
   const { canEdit } = useCanEdit({ requeteId: requestId });
   const userRole = useUserStore((s) => s.role);
   const canWrite = userRole
     ? ([ROLES.ENTITY_ADMIN, ROLES.NATIONAL_STEERING, ROLES.WRITER] as string[]).includes(userRole)
     : false;
 
-  const isSystemStep = rest.type !== REQUETE_ETAPE_TYPES.MANUAL || statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE;
   const isAcknowledgmentStep = rest.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
   const sendNote = isAcknowledgmentStep
     ? notes.find((note) => note.texte?.startsWith("Email d'accusé de réception envoyé le"))
     : undefined;
   const displayNotes = sendNote ? notes.filter((note) => note.id !== sendNote.id) : notes;
 
-  const badges = requeteEtapeStatutBadges.filter((badge) => {
-    if (statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) {
-      return true;
-    }
-    return badge.value !== REQUETE_ETAPE_STATUT_TYPES.CLOTUREE;
-  });
-
-  const handleStatusChange = (newStatutId: string) => {
-    if (newStatutId !== statutId && id && newStatutId !== 'CLOTUREE') {
-      updateStatusMutation.mutate({
-        id,
-        statutId: newStatutId as Exclude<RequeteEtapeStatutType, 'CLOTUREE'>,
-      });
-    }
-  };
-
-  const handleEditButton = (open: boolean) => {
-    setIsEditing(open);
-    setEditStepName(nom ?? '');
-    setEditError(null);
-  };
+  const showAFaireBadge = statutId === REQUETE_ETAPE_STATUT_TYPES.A_FAIRE;
+  const canEditStep = canEdit && rest.editable;
 
   const clotureReasonLabels =
     statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE
       ? rest.clotureReason.map((reason) => reason.label).filter(Boolean)
       : [];
-
-  const handleSaveEdit = () => {
-    const validationResult = UpdateProcessingStepNameSchema.safeParse({
-      stepName: editStepName,
-    });
-
-    if (!validationResult.success) {
-      const firstError = validationResult.error.issues[0];
-      setEditError(firstError.message);
-      return;
-    }
-
-    updateStepNameMutation.mutate({
-      id,
-      nom: validationResult.data.stepName,
-    });
-
-    setIsEditing(false);
-    setEditError(null);
-  };
-
-  const handleDeleteStep = async () => {
-    if (id) {
-      deleteStepMutation.mutate(
-        { id },
-        {
-          onSuccess: () => {
-            deleteStepModal.close();
-            toastManager.add({
-              title: 'Étape supprimée',
-              description: "L'étape a été supprimée avec succès.",
-              timeout: 0,
-              data: { icon: 'fr-alert--success' },
-            });
-          },
-        },
-      );
-    }
-  };
-
-  const handleDeleteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    registerTrigger(e.currentTarget);
-    deleteStepModal.open();
-  };
 
   const handleConfirmDeleteClotureFile = async () => {
     if (!fileToDelete) return;
@@ -299,107 +216,44 @@ const StepComponent = ({
     <div className={`fr-mb-4w ${styles['timeline-step']}`}>
       <div className={styles['timeline-dot']} />
       <div className={styles.step}>
-        {isEditing ? (
-          <div className="fr-mb-2w">
-            <Input
-              label="Nom de l'étape (obligatoire)"
-              nativeInputProps={{
-                value: editStepName,
-                onChange: (e) => {
-                  setEditStepName(e.target.value);
-                  setEditError(null);
-                },
-                placeholder: "Saisir le nom de l'étape",
-              }}
-              state={editError ? 'error' : 'default'}
-              stateRelatedMessage={editError}
-            />
-            <div className="fr-grid-row fr-grid-row--middle fr-mt-2w">
-              <div className="fr-col">
-                <ButtonLink icon="fr-icon-delete-line" onClick={handleDeleteClick}>
-                  Supprimer l'étape
-                </ButtonLink>
-              </div>
+        <div className="fr-mb-1w">
+          <div className="fr-grid-row fr-grid-row--middle">
+            <div className="fr-col">
+              <h3 className="fr-h6 fr-mb-0">{getStepTitle(rest.type, statutId, nom)}</h3>
+            </div>
+            {showAFaireBadge && (
               <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-                <div className="fr-grid-row">
-                  <Button
-                    className="fr-mr-1w"
-                    priority="secondary"
-                    size="small"
-                    onClick={() => handleEditButton(false)}
-                  >
-                    Annuler
-                  </Button>
-                  <Button
-                    priority="primary"
-                    size="small"
-                    onClick={handleSaveEdit}
-                    disabled={updateStepNameMutation.isPending}
-                  >
-                    {updateStepNameMutation.isPending ? 'Enregistrement...' : 'Modifier'}
+                <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--info">
+                  {requeteEtapeStatutType.A_FAIRE}
+                </span>
+              </div>
+            )}
+          </div>
+          <div className="fr-grid-row fr-grid-row--middle fr-mt-1w">
+            <div className="fr-col">
+              <p className="fr-text--xs fr-text-mention--grey">
+                {getStepSubtitle(
+                  rest.type,
+                  statutId,
+                  createdAt,
+                  updatedAt,
+                  createdBy,
+                  notes,
+                  requete,
+                  clotureEffectiveDate,
+                  rest.dateRealisation,
+                )}
+              </p>
+              {isAcknowledgmentSendable && canEdit && (
+                <div className="fr-mt-2w">
+                  <Button priority="secondary" size="small" onClick={onSendAcknowledgment}>
+                    Envoyer
                   </Button>
                 </div>
-              </div>
+              )}
             </div>
           </div>
-        ) : (
-          <div className="fr-mb-1w">
-            <div className="fr-grid-row fr-grid-row--middle">
-              <div className="fr-col">
-                <h3 className="fr-h6 fr-mb-0">{getStepTitle(rest.type, statutId, nom)}</h3>
-              </div>
-              <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-                <StatusMenu
-                  badges={badges}
-                  value={statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ? REQUETE_ETAPE_STATUT_TYPES.FAIT : statutId}
-                  disabled={disabled || !canEdit || updateStatusMutation.isPending}
-                  onBadgeClick={handleStatusChange}
-                />
-              </div>
-              <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-                {canEdit && !isSystemStep && (
-                  <Button
-                    priority="tertiary no outline"
-                    size="small"
-                    iconId="fr-icon-edit-line"
-                    title={`Modifier le nom de l'étape ${getStepTitle(rest.type, statutId, nom)}`}
-                    aria-label="Modifier le nom de l'étape"
-                    className="fr-btn--icon-center center-icon-with-sr-only"
-                    onClick={() => handleEditButton(true)}
-                    style={{ whiteSpace: 'nowrap' }}
-                  >
-                    <span className="fr-sr-only">
-                      Modifier le nom de l'étape {getStepTitle(rest.type, statutId, nom)}
-                    </span>
-                  </Button>
-                )}
-              </div>
-            </div>
-            <div className="fr-grid-row fr-grid-row--middle fr-mt-1w">
-              <div className="fr-col">
-                <p className="fr-text--xs fr-text-mention--grey">
-                  {getStepSubtitle(
-                    rest.type,
-                    statutId,
-                    createdAt,
-                    updatedAt,
-                    createdBy,
-                    notes,
-                    requete,
-                    clotureEffectiveDate,
-                  )}
-                </p>
-                {isAcknowledgmentSendable && canEdit && (
-                  <div className="fr-mt-2w">
-                    <Button priority="secondary" size="small" onClick={onSendAcknowledgment}>
-                      Envoyer
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
+        </div>
       </div>
       <div className={styles['request-step']}>
         {statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE ? (
@@ -489,7 +343,6 @@ const StepComponent = ({
             <div className={styles['request-notes']}>
               {displayNotes.slice(0, isOpen ? displayNotes.length : 3).map((note: StepType['notes'][number]) => (
                 <StepNote
-                  requestId={requestId}
                   key={note.id}
                   content={note.texte}
                   author={note.author}
@@ -504,23 +357,6 @@ const StepComponent = ({
                     sanitizeStatus: file.sanitizeStatus,
                   }))}
                   requeteStateId={id}
-                  onEdit={(noteData) =>
-                    openEditNote?.(
-                      {
-                        id,
-                        nom,
-                        statutId,
-                        notes,
-                        createdAt,
-                        updatedAt,
-                        createdBy,
-                        requete,
-                        clotureEffectiveDate,
-                        ...rest,
-                      },
-                      noteData,
-                    )
-                  }
                   clotureReasonLabels={null}
                 />
               ))}
@@ -538,12 +374,12 @@ const StepComponent = ({
                 </button>
               )}
             </div>
-            {canEdit && (!isSystemStep || isAcknowledgmentStep) && (
+            {canEditStep && (
               <Button
                 className={styles['request-step__add-note']}
                 type="button"
                 priority="tertiary"
-                iconId="fr-icon-add-line"
+                iconId="fr-icon-edit-line"
                 onClick={() =>
                   openEdit?.({
                     id,
@@ -559,7 +395,7 @@ const StepComponent = ({
                   })
                 }
               >
-                Ajouter une note ou un fichier
+                Modifier l'étape
               </Button>
             )}
           </>
@@ -579,26 +415,6 @@ const StepComponent = ({
           </>
         )}
       </div>
-
-      <deleteStepModal.Component
-        title="Suppression d'une étape"
-        buttons={[
-          {
-            doClosesModal: true,
-            children: 'Annuler',
-          },
-          {
-            doClosesModal: false,
-            children: 'Supprimer',
-            onClick: handleDeleteStep,
-          },
-        ]}
-      >
-        <p>
-          Êtes-vous sûr de vouloir supprimer cette étape ? La suppression de l'étape entraîne la suppression de toutes
-          les notes et fichiers liés à cette étape.
-        </p>
-      </deleteStepModal.Component>
 
       <deleteClotureFileModal.Component
         concealingBackdrop={false}

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.module.css
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.module.css
@@ -1,0 +1,98 @@
+.topActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.fieldBlock {
+  margin-top: 1.5rem;
+}
+
+.attachmentSection {
+  margin-top: 1.5rem;
+}
+
+.attachmentTitle {
+  margin-bottom: 0.75rem;
+}
+
+.drawerDropZone {
+  margin-top: 0;
+}
+
+.selectedFilesList {
+  margin-top: 1rem;
+}
+
+.errorText {
+  color: var(--text-default-error);
+}
+
+.notesSection {
+  margin-top: 1.5rem;
+}
+
+.noteCard {
+  margin-bottom: 1.5rem;
+}
+
+.noteHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.noteHeaderLabel {
+  font-weight: 700;
+  margin: 0;
+}
+
+.readOnlyNote {
+  border: 1px solid var(--border-default-grey);
+  border-radius: 0.5rem;
+  background: var(--background-alt-grey);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.readOnlyNoteLabel {
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+}
+
+.readOnlyNoteText {
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.existingFilesList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.existingFileItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.25rem 0;
+}
+
+.lockHint {
+  color: var(--text-mention-grey);
+}
+
+.footerActions {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-default-grey);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.module.css
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.module.css
@@ -38,14 +38,9 @@
 .noteHeader {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 0.5rem;
   margin-bottom: 0.25rem;
-}
-
-.noteHeaderLabel {
-  font-weight: 700;
-  margin: 0;
 }
 
 .readOnlyNote {

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
@@ -160,7 +160,7 @@ describe('StepFormPanel', () => {
     expect(screen.getByText(/Note du 02-01-2026 \(lecture seule\)/)).toBeInTheDocument();
   });
 
-  it('removes an editable note via its trash button', async () => {
+  it('removes an editable note via its delete button', async () => {
     const ref = createRef<StepFormPanelRef>();
     render(<StepFormPanel ref={ref} requestId="REQ-1" />);
 

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
@@ -1,0 +1,261 @@
+import { REQUETE_ETAPE_STATUT_TYPES, REQUETE_ETAPE_TYPES } from '@sirena/common/constants';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StepFormPanel, type StepFormPanelRef } from './StepFormPanel';
+
+const addMutateAsync = vi.fn();
+const updateMutateAsync = vi.fn();
+const deleteMutateAsync = vi.fn();
+const uploadMutateAsync = vi.fn();
+
+vi.mock('@/hooks/mutations/updateProcessingStep.hook', () => ({
+  useAddProcessingStep: () => ({ mutateAsync: addMutateAsync }),
+  useUpdateProcessingStep: () => ({ mutateAsync: updateMutateAsync }),
+  useDeleteProcessingStep: () => ({ mutateAsync: deleteMutateAsync }),
+}));
+
+vi.mock('@/hooks/mutations/updateUploadedFiles.hook', () => ({
+  useUploadFile: () => ({ mutateAsync: uploadMutateAsync }),
+}));
+
+vi.mock('@/components/common/FileDownloadLink', () => ({
+  FileDownloadLink: ({ fileName }: { fileName: string }) => <span>{fileName}</span>,
+}));
+
+vi.mock('@codegouvfr/react-dsfr/Modal', () => ({
+  createModal: () => ({
+    id: 'step-form-panel-delete',
+    open: vi.fn(),
+    close: vi.fn(),
+    // biome-ignore lint/suspicious/noExplicitAny: minimal modal mock
+    Component: ({ children, buttons }: any) => (
+      <div>
+        {children}
+        {/* biome-ignore lint/suspicious/noExplicitAny: minimal modal mock */}
+        {buttons?.map((b: any) => (
+          <button key={b.children} type="button" onClick={b.onClick}>
+            {b.children}
+          </button>
+        ))}
+      </div>
+    ),
+  }),
+}));
+
+vi.mock('@sirena/ui', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@sirena/ui')>();
+  return {
+    ...original,
+    Toast: { ...original.Toast, useToastManager: () => ({ add: vi.fn() }) },
+  };
+});
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal step shape for tests
+const makeStep = (overrides: Record<string, any> = {}): any => ({
+  id: 'step-1',
+  requeteId: 'REQ-1',
+  entiteId: 'ENT-1',
+  nom: 'Relance',
+  type: REQUETE_ETAPE_TYPES.MANUAL,
+  statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE,
+  dateRealisation: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  clotureEffectiveDate: null,
+  clotureReason: [],
+  createdBy: { prenom: 'cam', nom: 'd' },
+  notes: [],
+  uploadedFiles: [],
+  editable: true,
+  canOnlyEditNotes: false,
+  requete: { dematSocialId: null, createdById: 'u1', thirdPartyAccountId: null, createdBy: null },
+  ...overrides,
+});
+
+describe('StepFormPanel', () => {
+  beforeEach(() => {
+    addMutateAsync.mockReset().mockResolvedValue({ data: {} });
+    updateMutateAsync.mockReset().mockResolvedValue({ data: {} });
+    deleteMutateAsync.mockReset().mockResolvedValue(undefined);
+    uploadMutateAsync.mockReset().mockResolvedValue({ id: 'file-1' });
+  });
+
+  it('creates a step with no status selected by default (spec)', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() => ref.current?.openCreate());
+
+    fireEvent.change(screen.getByLabelText("Nom de l'étape (obligatoire)"), {
+      target: { value: 'Nouvelle étape' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }));
+    });
+
+    expect(addMutateAsync).toHaveBeenCalledTimes(1);
+    expect(addMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ nom: 'Nouvelle étape', fileIds: [] }));
+    expect(addMutateAsync.mock.calls[0][0].statutId).toBeUndefined();
+  });
+
+  it('sends statut and date when « Fait » is selected', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() => ref.current?.openCreate());
+
+    fireEvent.change(screen.getByLabelText("Nom de l'étape (obligatoire)"), {
+      target: { value: 'Étape faite' },
+    });
+    fireEvent.click(screen.getByLabelText('Fait'));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }));
+    });
+
+    expect(addMutateAsync).toHaveBeenCalledTimes(1);
+    const payload = addMutateAsync.mock.calls[0][0];
+    expect(payload.statutId).toBe(REQUETE_ETAPE_STATUT_TYPES.FAIT);
+    expect(payload.dateRealisation).toBeTruthy();
+  });
+
+  it('blocks creation when the name is empty', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() => ref.current?.openCreate());
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }));
+    });
+
+    expect(addMutateAsync).not.toHaveBeenCalled();
+    expect(screen.getByText(/Veuillez le renseigner pour ajouter une étape/)).toBeInTheDocument();
+  });
+
+  it('prefills the edit form and renders system notes as read-only', () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() =>
+      ref.current?.openEdit(
+        makeStep({
+          nom: 'Étape à modifier',
+          notes: [
+            {
+              id: 'n1',
+              texte: 'Note agent',
+              createdAt: '2026-01-02T00:00:00.000Z',
+              uploadedFiles: [],
+              author: { prenom: 'a', nom: 'b' },
+            },
+            { id: 'n2', texte: 'Note système', createdAt: '2026-01-02T00:00:00.000Z', uploadedFiles: [], author: null },
+          ],
+        }),
+      ),
+    );
+
+    expect(screen.getByDisplayValue('Étape à modifier')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Note agent')).toBeInTheDocument();
+    expect(screen.getByText('Note système')).toBeInTheDocument();
+    expect(screen.getByText(/Note du 02-01-2026 \(lecture seule\)/)).toBeInTheDocument();
+  });
+
+  it('removes an editable note via its trash button', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() =>
+      ref.current?.openEdit(
+        makeStep({
+          notes: [
+            {
+              id: 'n1',
+              texte: 'Note agent',
+              createdAt: '2026-01-02T00:00:00.000Z',
+              uploadedFiles: [],
+              author: { prenom: 'a', nom: 'b' },
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(screen.getByDisplayValue('Note agent')).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /supprimer la note du 02-01-2026/i }));
+    });
+    expect(screen.queryByDisplayValue('Note agent')).not.toBeInTheDocument();
+  });
+
+  it('sends the full desired state on edit (nom, statut, note id, fileIds)', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() =>
+      ref.current?.openEdit(
+        makeStep({
+          nom: 'Étape à modifier',
+          statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE,
+          notes: [
+            {
+              id: 'n1',
+              texte: 'Note agent',
+              createdAt: '2026-01-02T00:00:00.000Z',
+              uploadedFiles: [],
+              author: { prenom: 'a', nom: 'b' },
+            },
+          ],
+          uploadedFiles: [{ id: 'f1', fileName: 'doc.pdf', size: 10, canDelete: true }],
+        }),
+      ),
+    );
+
+    fireEvent.change(screen.getByDisplayValue('Étape à modifier'), { target: { value: 'Nouveau nom' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }));
+    });
+
+    expect(updateMutateAsync).toHaveBeenCalledTimes(1);
+    const payload = updateMutateAsync.mock.calls[0][0];
+    expect(payload.id).toBe('step-1');
+    expect(payload.nom).toBe('Nouveau nom');
+    expect(payload.statutId).toBe(REQUETE_ETAPE_STATUT_TYPES.A_FAIRE);
+    expect(payload.notes).toEqual([{ id: 'n1', texte: 'Note agent' }]);
+    expect(payload.fileIds).toEqual(['f1']);
+  });
+
+  it('deletes the step from the drawer', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() => ref.current?.openEdit(makeStep()));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Supprimer' }));
+    });
+
+    expect(deleteMutateAsync).toHaveBeenCalledWith({ id: 'step-1' });
+  });
+
+  it('locks status/name/files for an automatic ACR step (canOnlyEditNotes)', () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() =>
+      ref.current?.openEdit(
+        makeStep({
+          type: REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT,
+          statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT,
+          dateRealisation: '2026-05-20T00:00:00.000Z',
+          canOnlyEditNotes: true,
+        }),
+      ),
+    );
+
+    expect(screen.getByLabelText("Nom de l'étape (obligatoire)")).toBeDisabled();
+    expect(screen.getByLabelText('Fait')).toBeDisabled();
+    expect(screen.getByLabelText('À faire')).toBeDisabled();
+    expect(screen.queryByText('Sélectionner un fichier')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ajouter une note' })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -96,13 +96,13 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const generatedId = useId();
   const titleId = `${generatedId}-step-form`;
   const headingRef = useRef<HTMLHeadingElement>(null);
-  const triggerElementRef = useRef<HTMLElement | null>(null);
   const nomInputRef = useRef<HTMLInputElement>(null);
   const dateInputRef = useRef<HTMLInputElement>(null);
 
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<'create' | 'edit'>('create');
   const [editStepId, setEditStepId] = useState<string | null>(null);
+  const [editStepNom, setEditStepNom] = useState('');
   const [canOnlyEditNotes, setCanOnlyEditNotes] = useState(false);
 
   const [nom, setNom] = useState('');
@@ -129,6 +129,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const resetForm = () => {
     setNom('');
     setNomError(null);
+    setEditStepNom('');
     setStatutId(null);
     setDateRealisation('');
     setDateError(null);
@@ -141,7 +142,6 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   };
 
   const openCreate = () => {
-    triggerElementRef.current = (document.activeElement as HTMLElement) ?? null;
     resetForm();
     setMode('create');
     setEditStepId(null);
@@ -152,19 +152,17 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
 
   const openEdit = (step: StepType) => {
     if (!step.editable) return;
-    triggerElementRef.current = (document.activeElement as HTMLElement) ?? null;
     resetForm();
     setMode('edit');
     setEditStepId(step.id);
+    setEditStepNom(step.nom);
     setCanOnlyEditNotes(step.canOnlyEditNotes);
     setNom(step.nom);
 
     const initialStatut =
-      step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT
-        ? REQUETE_ETAPE_STATUT_TYPES.FAIT
-        : step.statutId === REQUETE_ETAPE_STATUT_TYPES.A_FAIRE
-          ? REQUETE_ETAPE_STATUT_TYPES.A_FAIRE
-          : null;
+      step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT || step.statutId === REQUETE_ETAPE_STATUT_TYPES.A_FAIRE
+        ? step.statutId
+        : null;
     setStatutId(initialStatut);
     setDateRealisation(
       step.dateRealisation
@@ -207,11 +205,11 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   useImperativeHandle(ref, () => ({ openCreate, openEdit, closeDrawer }));
 
   useEffect(() => {
-    if (isOpen) {
-      const id = window.setTimeout(() => headingRef.current?.focus(), 0);
-      return () => window.clearTimeout(id);
-    }
-    triggerElementRef.current?.focus();
+    if (!isOpen) return;
+    // À l'ouverture, on déplace le focus sur le titre du panneau ; la restauration
+    // du focus à la fermeture est assurée par Drawer.Root.
+    const id = window.setTimeout(() => headingRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
   }, [isOpen]);
 
   const handleOpenChange = (open: boolean) => {
@@ -387,7 +385,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                     </Button>
                   </div>
                   <h3 id={titleId} className="fr-h6" ref={headingRef} tabIndex={-1}>
-                    {mode === 'create' ? 'Ajouter une étape' : "Modifier l'étape"}
+                    {mode === 'create' ? 'Ajouter une étape' : `Modifier l'étape « ${editStepNom} »`}
                   </h3>
                   <p className="fr-text--sm fr-mb-2w">Sauf mention contraire, tous les champs sont facultatifs.</p>
 
@@ -491,7 +489,6 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                           <div key={note.key} className={mode === 'edit' ? styles.noteCard : undefined}>
                             {mode === 'edit' && (
                               <div className={styles.noteHeader}>
-                                <p className={styles.noteHeaderLabel}>{noteLabel}</p>
                                 <Button
                                   type="button"
                                   priority="tertiary"
@@ -505,7 +502,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                               </div>
                             )}
                             <Input
-                              label={mode === 'edit' ? <span className="fr-sr-only">{noteLabel}</span> : noteLabel}
+                              label={noteLabel}
                               hintText="Maximum 10 000 caractères"
                               textArea
                               disabled={isLoading}
@@ -561,7 +558,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                                   priority="tertiary"
                                   size="small"
                                   iconId="fr-icon-delete-line"
-                                  title="Retirer le fichier"
+                                  title={`Retirer le fichier ${file.originalName}`}
                                   aria-label={`Retirer le fichier ${file.originalName}`}
                                   disabled={isLoading}
                                   onClick={() => setExistingFiles((prev) => prev.filter((f) => f.id !== file.id))}

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -55,9 +55,10 @@ type ExistingFile = {
 };
 
 const NOTE_MAX_LENGTH = 10000;
-const NOTE_MAX_LENGTH_ERROR = 'Le texte de la note ne doit pas dépasser 10 000 caractères.';
+const NOTE_MAX_LENGTH_ERROR =
+  'Le champ "Ajouter une note à l\'étape" ne doit pas dépasser 10 000 caractères. Supprimer les caractères excédentaires.';
 const NOM_REQUIRED_ERROR = "Le champ 'Nom de l'étape' est obligatoire. Veuillez le renseigner pour ajouter une étape.";
-const DATE_REQUIRED_ERROR = 'La date de réalisation est obligatoire lorsque le statut est « Fait ».';
+const DATE_REQUIRED_ERROR = "La date de réalisation est obligatoire lorsque le statut de l'étape est « Fait ».";
 
 let noteKeySeq = 0;
 const nextNoteKey = () => {
@@ -96,6 +97,8 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const titleId = `${generatedId}-step-form`;
   const headingRef = useRef<HTMLHeadingElement>(null);
   const triggerElementRef = useRef<HTMLElement | null>(null);
+  const nomInputRef = useRef<HTMLInputElement>(null);
+  const dateInputRef = useRef<HTMLInputElement>(null);
 
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<'create' | 'edit'>('create');
@@ -115,7 +118,6 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const [filesToUpload, setFilesToUpload] = useState<File[]>([]);
   const [fileErrors, setFileErrors] = useState<Record<string, FileValidationError[]>>({});
 
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const addStepMutation = useAddProcessingStep(requestId);
@@ -135,7 +137,6 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
     setExistingFiles([]);
     setFilesToUpload([]);
     setFileErrors({});
-    setErrorMessage(null);
     setIsLoading(false);
   };
 
@@ -244,19 +245,21 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
       return [...prev, ...merged];
     });
     setFileErrors({});
-    setErrorMessage(null);
   };
 
   const validate = (): boolean => {
     let valid = true;
+    let firstErrorField: HTMLElement | null = null;
 
     if (!nom.trim()) {
       setNomError(NOM_REQUIRED_ERROR);
+      firstErrorField = firstErrorField ?? nomInputRef.current;
       valid = false;
     }
 
     if (!fieldsLocked && isFait && !dateRealisation) {
       setDateError(DATE_REQUIRED_ERROR);
+      firstErrorField = firstErrorField ?? dateInputRef.current;
       valid = false;
     }
 
@@ -268,6 +271,10 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
     if (Object.keys(newFileErrors).length > 0) {
       setFileErrors(newFileErrors);
       valid = false;
+    }
+
+    if (!valid && firstErrorField) {
+      firstErrorField.focus();
     }
 
     return valid;
@@ -285,7 +292,11 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
         uploadedIds = uploaded.map((u) => u.id);
       } catch {
         setIsLoading(false);
-        setErrorMessage('Une erreur est survenue lors du téléversement des fichiers. Veuillez réessayer.');
+        toastManager.add({
+          title: 'Erreur',
+          description: 'Une erreur est survenue lors du téléversement des fichiers. Veuillez réessayer.',
+          data: { icon: 'fr-alert--error' },
+        });
         return;
       }
     }
@@ -327,7 +338,11 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
       closeDrawer();
     } catch {
       setIsLoading(false);
-      setErrorMessage("Une erreur est survenue lors de l'enregistrement de l'étape. Veuillez réessayer.");
+      toastManager.add({
+        title: 'Erreur',
+        description: "Une erreur est survenue lors de l'enregistrement de l'étape. Veuillez réessayer.",
+        data: { icon: 'fr-alert--error' },
+      });
     }
   };
 
@@ -395,12 +410,12 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                       state={nomError ? 'error' : 'default'}
                       stateRelatedMessage={nomError ?? undefined}
                       nativeInputProps={{
+                        ref: nomInputRef,
                         value: nom,
                         onChange: (e) => {
                           setNom(e.target.value);
                           if (nomError) setNomError(null);
                         },
-                        placeholder: "Saisir le nom de l'étape",
                       }}
                     />
 
@@ -438,11 +453,12 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                       <div className={styles.fieldBlock}>
                         <Input
                           label="Fait le (obligatoire)"
-                          hintText="Date au format JJ-MM-AAAA"
+                          hintText="Format attendu : JJ-MM-AAAA"
                           disabled={isLoading || fieldsLocked}
                           state={dateError ? 'error' : 'default'}
                           stateRelatedMessage={dateError ?? undefined}
                           nativeInputProps={{
+                            ref: dateInputRef,
                             type: 'date',
                             value: dateRealisation,
                             onChange: (e) => {
@@ -465,7 +481,12 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                       ))}
 
                       {notes.map((note) => {
-                        const noteLabel = note.createdAt ? `Note du ${formatNoteDate(note.createdAt)}` : 'Note';
+                        const noteLabel = note.createdAt
+                          ? `Note du ${formatNoteDate(note.createdAt)}`
+                          : 'Ajouter une note';
+                        const noteDeleteLabel = note.createdAt
+                          ? `Supprimer la note du ${formatNoteDate(note.createdAt)}`
+                          : 'Supprimer la note';
                         return (
                           <div key={note.key} className={mode === 'edit' ? styles.noteCard : undefined}>
                             {mode === 'edit' && (
@@ -476,8 +497,8 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                                   priority="tertiary"
                                   size="small"
                                   iconId="fr-icon-delete-line"
-                                  title="Supprimer la note"
-                                  aria-label={`Supprimer la ${noteLabel.toLowerCase()}`}
+                                  title={noteDeleteLabel}
+                                  aria-label={noteDeleteLabel}
                                   disabled={isLoading}
                                   onClick={() => handleRemoveNote(note.key)}
                                 />
@@ -555,7 +576,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                     {!fieldsLocked && (
                       <section className={styles.attachmentSection}>
                         <p className={`fr-label ${styles.attachmentTitle}`}>
-                          {existingFiles.length > 0 ? "Ajouter d'autres fichiers" : 'Fichiers'}
+                          {existingFiles.length > 0 ? "Ajouter d'autres pièces jointes" : 'Ajouter des pièces jointes'}
                         </p>
                         <FileDropZone
                           selectedFiles={filesToUpload}
@@ -576,8 +597,6 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                         />
                       </section>
                     )}
-
-                    {errorMessage && <p className={`fr-text--sm fr-mt-2w ${styles.errorText}`}>{errorMessage}</p>}
 
                     <div className={styles.footerActions}>
                       {mode === 'edit' && !fieldsLocked && (

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -1,0 +1,630 @@
+import { Button } from '@codegouvfr/react-dsfr/Button';
+import { Input } from '@codegouvfr/react-dsfr/Input';
+import { createModal } from '@codegouvfr/react-dsfr/Modal';
+import { RadioButtons } from '@codegouvfr/react-dsfr/RadioButtons';
+import { REQUETE_ETAPE_STATUT_TYPES } from '@sirena/common/constants';
+import { Drawer, Toast } from '@sirena/ui';
+import { forwardRef, useEffect, useId, useImperativeHandle, useRef, useState } from 'react';
+import { FileDownloadLink } from '@/components/common/FileDownloadLink';
+import { FileDropZone } from '@/components/common/FileDropZone';
+import { SelectedFilesList } from '@/components/common/SelectedFilesList';
+import {
+  useAddProcessingStep,
+  useDeleteProcessingStep,
+  useUpdateProcessingStep,
+} from '@/hooks/mutations/updateProcessingStep.hook';
+import { useUploadFile } from '@/hooks/mutations/updateUploadedFiles.hook';
+import type { useProcessingSteps } from '@/hooks/queries/processingSteps.hook';
+import type { ProcessingStepStatut } from '@/lib/api/processingSteps';
+import { type FileValidationError, validateFiles } from '@/utils/fileValidation';
+import styles from './StepFormPanel.module.css';
+
+type StepType = NonNullable<ReturnType<typeof useProcessingSteps>['data']>['data'][number];
+
+export type StepFormPanelRef = {
+  openCreate: () => void;
+  openEdit: (step: StepType) => void;
+  closeDrawer: () => void;
+};
+
+type StepFormPanelProps = {
+  requestId: string;
+};
+
+type EditableNote = {
+  key: string;
+  id?: string;
+  texte: string;
+  createdAt?: string;
+};
+
+type ReadOnlyNote = {
+  id: string;
+  texte: string;
+  createdAt?: string;
+};
+
+type ExistingFile = {
+  id: string;
+  originalName: string;
+  size: number;
+  status?: string;
+  scanStatus?: string;
+  sanitizeStatus?: string;
+  canDelete: boolean;
+};
+
+const NOTE_MAX_LENGTH = 10000;
+const NOTE_MAX_LENGTH_ERROR = 'Le texte de la note ne doit pas dépasser 10 000 caractères.';
+const NOM_REQUIRED_ERROR = "Le champ 'Nom de l'étape' est obligatoire. Veuillez le renseigner pour ajouter une étape.";
+const DATE_REQUIRED_ERROR = 'La date de réalisation est obligatoire lorsque le statut est « Fait ».';
+
+let noteKeySeq = 0;
+const nextNoteKey = () => {
+  noteKeySeq += 1;
+  return `note-${noteKeySeq}`;
+};
+
+const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const toInputDate = (value: string | Date | null | undefined): string => {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return formatLocalDate(date);
+};
+
+const todayInputDate = () => formatLocalDate(new Date());
+
+const formatNoteDate = (value: string | Date): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${day}-${month}-${date.getFullYear()}`;
+};
+
+const deleteStepModal = createModal({ id: 'step-form-panel-delete', isOpenedByDefault: false });
+
+export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({ requestId }, ref) => {
+  const generatedId = useId();
+  const titleId = `${generatedId}-step-form`;
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const triggerElementRef = useRef<HTMLElement | null>(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [mode, setMode] = useState<'create' | 'edit'>('create');
+  const [editStepId, setEditStepId] = useState<string | null>(null);
+  const [canOnlyEditNotes, setCanOnlyEditNotes] = useState(false);
+
+  const [nom, setNom] = useState('');
+  const [nomError, setNomError] = useState<string | null>(null);
+  const [statutId, setStatutId] = useState<ProcessingStepStatut | null>(null);
+  const [dateRealisation, setDateRealisation] = useState('');
+  const [dateError, setDateError] = useState<string | null>(null);
+
+  const [notes, setNotes] = useState<EditableNote[]>([]);
+  const [readOnlyNotes, setReadOnlyNotes] = useState<ReadOnlyNote[]>([]);
+
+  const [existingFiles, setExistingFiles] = useState<ExistingFile[]>([]);
+  const [filesToUpload, setFilesToUpload] = useState<File[]>([]);
+  const [fileErrors, setFileErrors] = useState<Record<string, FileValidationError[]>>({});
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const addStepMutation = useAddProcessingStep(requestId);
+  const updateStepMutation = useUpdateProcessingStep(requestId);
+  const deleteStepMutation = useDeleteProcessingStep(requestId);
+  const uploadFileMutation = useUploadFile({ silentToastError: true });
+  const toastManager = Toast.useToastManager();
+
+  const resetForm = () => {
+    setNom('');
+    setNomError(null);
+    setStatutId(null);
+    setDateRealisation('');
+    setDateError(null);
+    setNotes([]);
+    setReadOnlyNotes([]);
+    setExistingFiles([]);
+    setFilesToUpload([]);
+    setFileErrors({});
+    setErrorMessage(null);
+    setIsLoading(false);
+  };
+
+  const openCreate = () => {
+    triggerElementRef.current = (document.activeElement as HTMLElement) ?? null;
+    resetForm();
+    setMode('create');
+    setEditStepId(null);
+    setCanOnlyEditNotes(false);
+    setNotes([{ key: nextNoteKey(), texte: '' }]);
+    setIsOpen(true);
+  };
+
+  const openEdit = (step: StepType) => {
+    if (!step.editable) return;
+    triggerElementRef.current = (document.activeElement as HTMLElement) ?? null;
+    resetForm();
+    setMode('edit');
+    setEditStepId(step.id);
+    setCanOnlyEditNotes(step.canOnlyEditNotes);
+    setNom(step.nom);
+
+    const initialStatut =
+      step.statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT
+        ? REQUETE_ETAPE_STATUT_TYPES.FAIT
+        : step.statutId === REQUETE_ETAPE_STATUT_TYPES.A_FAIRE
+          ? REQUETE_ETAPE_STATUT_TYPES.A_FAIRE
+          : null;
+    setStatutId(initialStatut);
+    setDateRealisation(
+      step.dateRealisation
+        ? toInputDate(step.dateRealisation as unknown as string)
+        : initialStatut === REQUETE_ETAPE_STATUT_TYPES.FAIT
+          ? todayInputDate()
+          : '',
+    );
+
+    setNotes(
+      step.notes
+        .filter((note) => note.author !== null)
+        .map((note) => ({ key: nextNoteKey(), id: note.id, texte: note.texte, createdAt: note.createdAt })),
+    );
+    setReadOnlyNotes(
+      step.notes
+        .filter((note) => note.author === null)
+        .map((note) => ({ id: note.id, texte: note.texte, createdAt: note.createdAt })),
+    );
+
+    setExistingFiles(
+      step.uploadedFiles.map((file) => ({
+        id: file.id,
+        originalName: file.fileName,
+        size: file.size,
+        status: file.status,
+        scanStatus: file.scanStatus,
+        sanitizeStatus: file.sanitizeStatus,
+        canDelete: file.canDelete,
+      })),
+    );
+    setIsOpen(true);
+  };
+
+  const closeDrawer = () => {
+    resetForm();
+    setIsOpen(false);
+  };
+
+  useImperativeHandle(ref, () => ({ openCreate, openEdit, closeDrawer }));
+
+  useEffect(() => {
+    if (isOpen) {
+      const id = window.setTimeout(() => headingRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+    triggerElementRef.current?.focus();
+  }, [isOpen]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      resetForm();
+    }
+    setIsOpen(open);
+  };
+
+  const isFait = statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT;
+  const fieldsLocked = canOnlyEditNotes;
+
+  const handleAddNote = () => {
+    setNotes((prev) => [...prev, { key: nextNoteKey(), texte: '' }]);
+  };
+
+  const handleRemoveNote = (key: string) => {
+    setNotes((prev) => prev.filter((note) => note.key !== key));
+  };
+
+  const handleNoteChange = (key: string, value: string) => {
+    setNotes((prev) => prev.map((note) => (note.key === key ? { ...note, texte: value } : note)));
+  };
+
+  const handleSelectFiles = (selected: File[]) => {
+    setFilesToUpload((prev) => {
+      const existingNames = new Set(prev.map((f) => f.name));
+      const merged = selected
+        .filter((f) => !existingNames.has(f.name))
+        .map((f) => new File([f], f.name, { type: f.type }));
+      return [...prev, ...merged];
+    });
+    setFileErrors({});
+    setErrorMessage(null);
+  };
+
+  const validate = (): boolean => {
+    let valid = true;
+
+    if (!nom.trim()) {
+      setNomError(NOM_REQUIRED_ERROR);
+      valid = false;
+    }
+
+    if (!fieldsLocked && isFait && !dateRealisation) {
+      setDateError(DATE_REQUIRED_ERROR);
+      valid = false;
+    }
+
+    if (notes.some((note) => note.texte.length > NOTE_MAX_LENGTH)) {
+      valid = false;
+    }
+
+    const newFileErrors = validateFiles(filesToUpload);
+    if (Object.keys(newFileErrors).length > 0) {
+      setFileErrors(newFileErrors);
+      valid = false;
+    }
+
+    return valid;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+
+    setIsLoading(true);
+
+    let uploadedIds: string[] = [];
+    if (filesToUpload.length > 0) {
+      try {
+        const uploaded = await Promise.all(filesToUpload.map((file) => uploadFileMutation.mutateAsync(file)));
+        uploadedIds = uploaded.map((u) => u.id);
+      } catch {
+        setIsLoading(false);
+        setErrorMessage('Une erreur est survenue lors du téléversement des fichiers. Veuillez réessayer.');
+        return;
+      }
+    }
+
+    const cleanedNotes = notes
+      .map((note) => ({ ...note, texte: note.texte.trim() }))
+      .filter((note) => note.texte.length > 0);
+
+    try {
+      if (mode === 'create') {
+        await addStepMutation.mutateAsync({
+          nom: nom.trim(),
+          ...(statutId ? { statutId } : {}),
+          ...(isFait ? { dateRealisation } : {}),
+          notes: cleanedNotes.map((note) => ({ texte: note.texte })),
+          fileIds: uploadedIds,
+        });
+        toastManager.add({
+          title: 'Étape ajoutée',
+          description: "L'étape a été ajoutée avec succès.",
+          data: { icon: 'fr-alert--success' },
+        });
+      } else if (editStepId) {
+        const fileIds = [...existingFiles.map((f) => f.id), ...uploadedIds];
+        await updateStepMutation.mutateAsync({
+          id: editStepId,
+          nom: nom.trim(),
+          statutId,
+          ...(isFait ? { dateRealisation: dateRealisation || todayInputDate() } : {}),
+          notes: cleanedNotes.map((note) => ({ ...(note.id ? { id: note.id } : {}), texte: note.texte })),
+          fileIds,
+        });
+        toastManager.add({
+          title: 'Étape modifiée',
+          description: "L'étape a été modifiée avec succès.",
+          data: { icon: 'fr-alert--success' },
+        });
+      }
+      closeDrawer();
+    } catch {
+      setIsLoading(false);
+      setErrorMessage("Une erreur est survenue lors de l'enregistrement de l'étape. Veuillez réessayer.");
+    }
+  };
+
+  const handleDeleteStep = async () => {
+    if (!editStepId) return;
+    try {
+      await deleteStepMutation.mutateAsync({ id: editStepId });
+      toastManager.add({
+        title: 'Étape supprimée',
+        description: "L'étape a été supprimée avec succès.",
+        data: { icon: 'fr-alert--success' },
+      });
+      deleteStepModal.close();
+      closeDrawer();
+    } catch {
+      toastManager.add({
+        title: 'Erreur',
+        description: "Une erreur est survenue lors de la suppression de l'étape.",
+        data: { icon: 'fr-alert--error' },
+      });
+    }
+  };
+
+  return (
+    <>
+      <Drawer.Root variant="nonModal" withCloseButton={false} open={isOpen} onOpenChange={handleOpenChange}>
+        <Drawer.Portal>
+          <Drawer.Panel style={{ width: 'min(90vw, 600px)', maxWidth: '100%' }} titleId={titleId}>
+            <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+              {/* Extra bottom padding so the footer can scroll clear of the floating « Assistance » button. */}
+              <div style={{ flex: 1, overflowY: 'auto', padding: '0 16px 120px 16px' }}>
+                <div className="fr-container fr-mt-8w">
+                  <div className={styles.topActions}>
+                    <Button
+                      type="button"
+                      priority="tertiary no outline"
+                      iconId="fr-icon-close-line"
+                      onClick={() => setIsOpen(false)}
+                      disabled={isLoading}
+                    >
+                      Fermer
+                    </Button>
+                  </div>
+                  <h3 id={titleId} className="fr-h6" ref={headingRef} tabIndex={-1}>
+                    {mode === 'create' ? 'Ajouter une étape' : "Modifier l'étape"}
+                  </h3>
+                  <p className="fr-text--sm fr-mb-2w">Sauf mention contraire, tous les champs sont facultatifs.</p>
+
+                  {fieldsLocked && (
+                    <p className={`fr-text--sm ${styles.lockHint}`}>
+                      Cette étape correspond à un accusé de réception automatique : seules les notes peuvent être
+                      ajoutées ou modifiées.
+                    </p>
+                  )}
+
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      handleSubmit();
+                    }}
+                  >
+                    <Input
+                      label="Nom de l'étape (obligatoire)"
+                      disabled={isLoading || fieldsLocked}
+                      state={nomError ? 'error' : 'default'}
+                      stateRelatedMessage={nomError ?? undefined}
+                      nativeInputProps={{
+                        value: nom,
+                        onChange: (e) => {
+                          setNom(e.target.value);
+                          if (nomError) setNomError(null);
+                        },
+                        placeholder: "Saisir le nom de l'étape",
+                      }}
+                    />
+
+                    <div className={styles.fieldBlock}>
+                      <RadioButtons
+                        legend="Statut de l'étape"
+                        orientation="horizontal"
+                        disabled={isLoading || fieldsLocked}
+                        options={[
+                          {
+                            label: 'Fait',
+                            nativeInputProps: {
+                              checked: statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT,
+                              onChange: () => {
+                                setStatutId(REQUETE_ETAPE_STATUT_TYPES.FAIT);
+                                if (!dateRealisation) setDateRealisation(todayInputDate());
+                              },
+                            },
+                          },
+                          {
+                            label: 'À faire',
+                            nativeInputProps: {
+                              checked: statutId === REQUETE_ETAPE_STATUT_TYPES.A_FAIRE,
+                              onChange: () => {
+                                setStatutId(REQUETE_ETAPE_STATUT_TYPES.A_FAIRE);
+                                setDateError(null);
+                              },
+                            },
+                          },
+                        ]}
+                      />
+                    </div>
+
+                    {isFait && (
+                      <div className={styles.fieldBlock}>
+                        <Input
+                          label="Fait le (obligatoire)"
+                          hintText="Date au format JJ-MM-AAAA"
+                          disabled={isLoading || fieldsLocked}
+                          state={dateError ? 'error' : 'default'}
+                          stateRelatedMessage={dateError ?? undefined}
+                          nativeInputProps={{
+                            type: 'date',
+                            value: dateRealisation,
+                            onChange: (e) => {
+                              setDateRealisation(e.target.value);
+                              if (dateError) setDateError(null);
+                            },
+                          }}
+                        />
+                      </div>
+                    )}
+
+                    <section className={styles.notesSection}>
+                      {readOnlyNotes.map((note) => (
+                        <div key={note.id} className={styles.readOnlyNote}>
+                          <p className={styles.readOnlyNoteLabel}>
+                            {note.createdAt ? `Note du ${formatNoteDate(note.createdAt)}` : 'Note'} (lecture seule)
+                          </p>
+                          <p className={styles.readOnlyNoteText}>{note.texte}</p>
+                        </div>
+                      ))}
+
+                      {notes.map((note) => {
+                        const noteLabel = note.createdAt ? `Note du ${formatNoteDate(note.createdAt)}` : 'Note';
+                        return (
+                          <div key={note.key} className={mode === 'edit' ? styles.noteCard : undefined}>
+                            {mode === 'edit' && (
+                              <div className={styles.noteHeader}>
+                                <p className={styles.noteHeaderLabel}>{noteLabel}</p>
+                                <Button
+                                  type="button"
+                                  priority="tertiary"
+                                  size="small"
+                                  iconId="fr-icon-delete-line"
+                                  title="Supprimer la note"
+                                  aria-label={`Supprimer la ${noteLabel.toLowerCase()}`}
+                                  disabled={isLoading}
+                                  onClick={() => handleRemoveNote(note.key)}
+                                />
+                              </div>
+                            )}
+                            <Input
+                              label={mode === 'edit' ? <span className="fr-sr-only">{noteLabel}</span> : noteLabel}
+                              hintText="Maximum 10 000 caractères"
+                              textArea
+                              disabled={isLoading}
+                              state={note.texte.length > NOTE_MAX_LENGTH ? 'error' : 'default'}
+                              stateRelatedMessage={
+                                note.texte.length > NOTE_MAX_LENGTH ? NOTE_MAX_LENGTH_ERROR : undefined
+                              }
+                              nativeTextAreaProps={{
+                                rows: 6,
+                                value: note.texte,
+                                onChange: (e) => handleNoteChange(note.key, e.target.value),
+                              }}
+                            />
+                          </div>
+                        );
+                      })}
+
+                      {mode === 'edit' && (
+                        <Button
+                          type="button"
+                          priority="tertiary"
+                          size="small"
+                          iconId="fr-icon-add-line"
+                          disabled={isLoading}
+                          onClick={handleAddNote}
+                        >
+                          {notes.length === 0 && readOnlyNotes.length === 0
+                            ? 'Ajouter une note'
+                            : 'Ajouter une autre note'}
+                        </Button>
+                      )}
+                    </section>
+
+                    {existingFiles.length > 0 && (
+                      <section className={styles.attachmentSection}>
+                        <p className={`fr-label ${styles.attachmentTitle}`}>Fichiers ajoutés</p>
+                        <ul className={styles.existingFilesList}>
+                          {existingFiles.map((file) => (
+                            <li key={file.id} className={styles.existingFileItem}>
+                              <FileDownloadLink
+                                href={`/api/requete-etapes/${editStepId}/file/${file.id}`}
+                                safeHref={`/api/requete-etapes/${editStepId}/file/${file.id}/safe`}
+                                fileName={file.originalName}
+                                fileId={file.id}
+                                fileSize={file.size}
+                                status={file.status}
+                                scanStatus={file.scanStatus}
+                                sanitizeStatus={file.sanitizeStatus}
+                              />
+                              {!fieldsLocked && file.canDelete && (
+                                <Button
+                                  type="button"
+                                  priority="tertiary"
+                                  size="small"
+                                  iconId="fr-icon-delete-line"
+                                  title="Retirer le fichier"
+                                  aria-label={`Retirer le fichier ${file.originalName}`}
+                                  disabled={isLoading}
+                                  onClick={() => setExistingFiles((prev) => prev.filter((f) => f.id !== file.id))}
+                                />
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      </section>
+                    )}
+
+                    {!fieldsLocked && (
+                      <section className={styles.attachmentSection}>
+                        <p className={`fr-label ${styles.attachmentTitle}`}>
+                          {existingFiles.length > 0 ? "Ajouter d'autres fichiers" : 'Fichiers'}
+                        </p>
+                        <FileDropZone
+                          selectedFiles={filesToUpload}
+                          fileErrors={fileErrors}
+                          isUploading={isLoading}
+                          onFilesSelect={handleSelectFiles}
+                          title="Sélectionner ou glisser un fichier à joindre"
+                          buttonLabel="Sélectionner un fichier"
+                          className={styles.drawerDropZone}
+                          errorTextClassName={styles.errorText}
+                        />
+                        <SelectedFilesList
+                          files={filesToUpload}
+                          title="Fichiers sélectionnés"
+                          className={styles.selectedFilesList}
+                          variant="compact"
+                          onRemove={(fileName) => setFilesToUpload((prev) => prev.filter((f) => f.name !== fileName))}
+                        />
+                      </section>
+                    )}
+
+                    {errorMessage && <p className={`fr-text--sm fr-mt-2w ${styles.errorText}`}>{errorMessage}</p>}
+
+                    <div className={styles.footerActions}>
+                      {mode === 'edit' && !fieldsLocked && (
+                        <Button
+                          type="button"
+                          priority="secondary"
+                          size="small"
+                          iconId="fr-icon-delete-line"
+                          disabled={isLoading}
+                          style={{ marginRight: 'auto' }}
+                          onClick={() => deleteStepModal.open()}
+                        >
+                          Supprimer l'étape
+                        </Button>
+                      )}
+                      <Button
+                        type="button"
+                        priority="secondary"
+                        size="small"
+                        onClick={() => setIsOpen(false)}
+                        disabled={isLoading}
+                      >
+                        Annuler
+                      </Button>
+                      <Button type="submit" priority="primary" size="small" disabled={isLoading}>
+                        {isLoading ? 'Enregistrement...' : 'Enregistrer'}
+                      </Button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </Drawer.Panel>
+        </Drawer.Portal>
+      </Drawer.Root>
+      <deleteStepModal.Component
+        title="Suppression d'une étape"
+        buttons={[
+          { doClosesModal: true, children: 'Annuler' },
+          { doClosesModal: false, children: 'Supprimer', onClick: handleDeleteStep },
+        ]}
+      >
+        <p>
+          Êtes-vous sûr de vouloir supprimer cette étape ? La suppression de l'étape entraîne la suppression de toutes
+          les notes et fichiers liés à cette étape.
+        </p>
+      </deleteStepModal.Component>
+    </>
+  );
+});

--- a/apps/frontend/src/components/requestId/processing/StepNote.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepNote.tsx
@@ -1,8 +1,6 @@
-import { Button } from '@codegouvfr/react-dsfr/Button';
 import clsx from 'clsx';
 import { FileDownloadLink } from '@/components/common/FileDownloadLink';
 import { capitalizeFirst } from '@/components/requestId/sections/helpers';
-import { useCanEdit } from '@/hooks/useCanEdit';
 import styles from '@/routes/_auth/_user/request.$requestId.module.css';
 
 type StepNoteProps = {
@@ -10,7 +8,6 @@ type StepNoteProps = {
   content: string;
   createdAt: string;
   requeteStateId: string;
-  requestId: string;
   clotureReasonLabels: string[] | null;
   author?: {
     prenom: string;
@@ -25,45 +22,9 @@ type StepNoteProps = {
     sanitizeStatus?: string;
     safeFilePath?: string | null;
   }[];
-  onEdit?: (noteData: {
-    id: string;
-    requeteStateId: string;
-    content: string;
-    files: {
-      id: string;
-      size: number;
-      originalName: string;
-      status?: string;
-      scanStatus?: string;
-      sanitizeStatus?: string;
-      safeFilePath?: string | null;
-    }[];
-  }) => void;
 };
 
-export const StepNote = ({
-  id,
-  author,
-  content,
-  createdAt,
-  requeteStateId,
-  requestId,
-  files,
-  onEdit,
-  clotureReasonLabels,
-}: StepNoteProps) => {
-  const { canEdit } = useCanEdit({ requeteId: requestId });
-  const isSystemNote = author === null;
-
-  const handleEdit = () => {
-    onEdit?.({
-      id,
-      requeteStateId,
-      content,
-      files,
-    });
-  };
-
+export const StepNote = ({ author, content, createdAt, requeteStateId, files, clotureReasonLabels }: StepNoteProps) => {
   return (
     <div className={styles['request-note']}>
       <div className="fr-grid-row fr-grid-row--middle fr-mb-1v">
@@ -86,22 +47,6 @@ export const StepNote = ({
             </>
           )}
         </p>
-        <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-          {canEdit && !isSystemNote && (
-            <Button
-              priority="tertiary no outline"
-              size="small"
-              iconId="fr-icon-edit-line"
-              title="Modifier la note"
-              aria-label="Modifier la note"
-              className="fr-btn--icon-center center-icon-with-sr-only"
-              onClick={handleEdit}
-              style={{ whiteSpace: 'nowrap' }}
-            >
-              <span className="fr-sr-only">Modifier la note</span>
-            </Button>
-          )}
-        </div>
       </div>
       {clotureReasonLabels && (
         <div>

--- a/apps/frontend/src/hooks/mutations/updateProcessingStep.hook.ts
+++ b/apps/frontend/src/hooks/mutations/updateProcessingStep.hook.ts
@@ -8,7 +8,9 @@ import {
   deleteProcessingStep,
   deleteProcessingStepNote,
   sendAcknowledgment,
+  type UpdateProcessingStepData,
   type UpdateProcessingStepNoteData,
+  updateProcessingStep,
   updateProcessingStepNote,
   updateProcessingStepStatus,
 } from '@/lib/api/processingSteps';
@@ -18,6 +20,21 @@ export const useAddProcessingStep = (requestId: string) => {
 
   return useMutation({
     mutationFn: (data: AddProcessingStepData) => addProcessingStep(requestId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['processingSteps', requestId] });
+    },
+  });
+};
+
+type UpdateProcessingStepParams = {
+  id: string;
+} & UpdateProcessingStepData;
+
+export const useUpdateProcessingStep = (requestId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, ...data }: UpdateProcessingStepParams) => updateProcessingStep(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['processingSteps', requestId] });
     },

--- a/apps/frontend/src/lib/api/processingSteps.ts
+++ b/apps/frontend/src/lib/api/processingSteps.ts
@@ -10,14 +10,54 @@ export async function fetchProcessingSteps(requestId: string) {
   return res.json();
 }
 
+export type ProcessingStepStatut = Exclude<RequeteEtapeStatutType, 'EN_COURS' | 'CLOTUREE'>;
+
+export type ProcessingStepNoteInput = {
+  id?: string;
+  texte: string;
+};
+
 export type AddProcessingStepData = {
   nom: string;
+  statutId?: ProcessingStepStatut;
+  dateRealisation?: string;
+  notes?: { texte: string }[];
+  fileIds?: string[];
 };
 
 export async function addProcessingStep(requestId: string, data: AddProcessingStepData) {
   const res = await client['requete-etapes'][':id']['processing-steps'].$post({
     param: { id: requestId },
-    json: { nom: data.nom },
+    json: {
+      nom: data.nom,
+      ...(data.statutId ? { statutId: data.statutId } : {}),
+      ...(data.dateRealisation ? { dateRealisation: data.dateRealisation } : {}),
+      notes: data.notes ?? [],
+      fileIds: data.fileIds ?? [],
+    },
+  });
+  await handleRequestErrors(res);
+  return res.json();
+}
+
+export type UpdateProcessingStepData = {
+  nom: string;
+  statutId?: ProcessingStepStatut | null;
+  dateRealisation?: string;
+  notes: ProcessingStepNoteInput[];
+  fileIds: string[];
+};
+
+export async function updateProcessingStep(stepId: string, data: UpdateProcessingStepData) {
+  const res = await client['requete-etapes'][':id'].$patch({
+    param: { id: stepId },
+    json: {
+      nom: data.nom,
+      statutId: data.statutId ?? null,
+      ...(data.dateRealisation ? { dateRealisation: data.dateRealisation } : {}),
+      notes: data.notes,
+      fileIds: data.fileIds,
+    },
   });
   await handleRequestErrors(res);
   return res.json();

--- a/apps/frontend/tests/requetesDetails.spec.ts
+++ b/apps/frontend/tests/requetesDetails.spec.ts
@@ -67,7 +67,7 @@ test.describe('Request Details Feature', () => {
     await expect(inputEtape).toBeVisible();
     await inputEtape.fill(randomStepName);
 
-    await page.getByRole('button', { name: 'Ajouter', exact: true }).click();
+    await page.getByRole('button', { name: 'Enregistrer', exact: true }).click();
 
     await expect(page.getByRole('heading', { name: randomStepName, level: 3 })).toBeVisible({ timeout: 10000 });
 


### PR DESCRIPTION
## Front
- Nouveau **`StepFormPanel`** (drawer) création + édition : nom, statut (radios), « Fait le », notes (1 à la création / N à l'édition), fichiers, suppression d'étape.
- **Statut facultatif** (rien pré-coché) ; « Fait le » requis seulement si « Fait ». Notes système en lecture seule.
- **`Step.tsx` consolidé** : fini l'édition inline / menu statut / crayons → un seul bouton **« Modifier l'étape »**. Badge « À faire » lecture seule, sous-titre « • Fait le {date} ». Modifiabilité déléguée au back.
- a11y : focus ouverture/fermeture, labels, erreurs.

## Back
- `Add/Update…BodySchema` : `statutId` optionnel/nullable, date requise si « Fait ».
- `create/updateProcessingEtape` : statut `null` si non fourni (plus de défaut `A_FAIRE`).
- `getEtapeEditability` : tout AR = notes seules (`ackNotesOnly`).

