### PR TITLE
feat: PR8 — nouvel affichage timeline (fichiers niveau étape)

### DIFF
--- a/apps/frontend/src/components/requestId/processing/Step.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.test.tsx
@@ -8,6 +8,10 @@ vi.mock('./AddFilesClotureDrawer', () => ({
   AddFilesClotureDrawer: forwardRef(() => null),
 }));
 
+vi.mock('@/components/common/FileDownloadLink', () => ({
+  FileDownloadLink: ({ fileName }: { fileName: string }) => <a href="#test">{fileName}</a>,
+}));
+
 vi.mock('@codegouvfr/react-dsfr/Modal', () => ({
   createModal: () => ({
     id: 'test-modal',
@@ -43,6 +47,9 @@ vi.mock('@/hooks/useModalFocusRestore', () => ({
 vi.mock('@/stores/userStore', () => ({
   useUserStore: (selector: (state: { role: string }) => string) => selector({ role: ROLES.WRITER }),
 }));
+
+type StepProps = React.ComponentProps<typeof Step>;
+type StepFile = StepProps['uploadedFiles'][number];
 
 describe('Step', () => {
   it('displays a closed step using the Date de clôture instead of the technical creation date', () => {
@@ -108,5 +115,118 @@ describe('Step', () => {
     render(<Step {...closureStep} />);
 
     expect(screen.getByRole('button', { name: /Ajouter un fichier/ })).toBeInTheDocument();
+  });
+
+  const makeFile = (overrides: Partial<StepFile> = {}): StepFile => ({
+    id: 'file-1',
+    size: 22528,
+    fileName: 'doc.pdf',
+    status: 'READY',
+    scanStatus: 'CLEAN',
+    sanitizeStatus: 'COMPLETED',
+    canDelete: true,
+    createdAt: '2026-05-19T10:00:00.000Z',
+    uploadedBy: { prenom: 'jeanne', nom: 'Moulon' },
+    ...overrides,
+  });
+
+  const makeStep = (overrides: Partial<StepProps> = {}): StepProps => ({
+    requestId: 'REQ-1',
+    requeteId: 'REQ-1',
+    entiteId: 'ENTITE-1',
+    id: 'step-1',
+    nom: 'Analyse du MSIP',
+    type: REQUETE_ETAPE_TYPES.MANUAL,
+    statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT,
+    createdAt: '2026-05-19T10:00:00.000Z',
+    updatedAt: '2026-05-19T10:00:00.000Z',
+    clotureEffectiveDate: null,
+    createdBy: { prenom: 'jeanne', nom: 'moulon' },
+    dateRealisation: '2026-05-19T10:00:00.000Z',
+    notes: [],
+    uploadedFiles: [],
+    editable: false,
+    canOnlyEditNotes: false,
+    requete: { dematSocialId: null, createdById: 'AGENT-1', thirdPartyAccountId: null, createdBy: null },
+    clotureReason: [],
+    ...overrides,
+  });
+
+  it('renders a note block with the "Note rédigée le … par …" wording', () => {
+    render(
+      <Step
+        {...makeStep({
+          notes: [
+            {
+              id: 'note-1',
+              texte: 'Texte de la note',
+              createdAt: '2026-05-19T10:00:00.000Z',
+              author: { prenom: 'jeanne', nom: 'Moulon' },
+              uploadedFiles: [],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Note rédigée le 19\/05\/2026/)).toBeInTheDocument();
+    expect(screen.getByText('Texte de la note')).toBeInTheDocument();
+  });
+
+  it('renders each step-level file as its own "Fichier ajouté le … par …" event', () => {
+    render(
+      <Step
+        {...makeStep({
+          uploadedFiles: [makeFile({ id: 'f1', fileName: 'a.pdf' }), makeFile({ id: 'f2', fileName: 'b.pdf' })],
+        })}
+      />,
+    );
+
+    expect(screen.getAllByText(/Fichier ajouté le 19\/05\/2026/)).toHaveLength(2);
+    expect(screen.getByText('a.pdf')).toBeInTheDocument();
+    expect(screen.getByText('b.pdf')).toBeInTheDocument();
+  });
+
+  it('derives the manual ACR subtitle from the AR file (Envoyé le … par …)', () => {
+    render(
+      <Step
+        {...makeStep({
+          type: REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT,
+          uploadedFiles: [
+            makeFile({
+              id: 'ar',
+              canDelete: false,
+              createdAt: '2026-05-20T10:00:00.000Z',
+              uploadedBy: { prenom: 'jeanne', nom: 'Moulon' },
+              fileName: 'AR.pdf',
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Envoyé le 20\/05\/2026/)).toBeInTheDocument();
+  });
+
+  it('shows "Envoyé automatiquement" for an automatic ACR file (no uploadedBy)', () => {
+    render(
+      <Step
+        {...makeStep({
+          type: REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT,
+          requete: { dematSocialId: 1, createdById: null, thirdPartyAccountId: null, createdBy: null },
+          uploadedFiles: [
+            makeFile({
+              id: 'ar',
+              canDelete: false,
+              createdAt: '2026-05-20T10:00:00.000Z',
+              uploadedBy: null,
+              fileName: 'AR.pdf',
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Envoyé automatiquement le 20\/05\/2026/)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -12,7 +12,6 @@ import { Toast } from '@sirena/ui';
 import { clsx } from 'clsx';
 import { memo, useMemo, useRef, useState } from 'react';
 import { FileDownloadLink } from '@/components/common/FileDownloadLink';
-import { capitalizeFirst } from '@/components/requestId/sections/helpers';
 import { useDeleteUploadedFile } from '@/hooks/mutations/updateUploadedFiles.hook';
 import type { useProcessingSteps } from '@/hooks/queries/processingSteps.hook';
 import { useCanEdit } from '@/hooks/useCanEdit';
@@ -20,7 +19,9 @@ import { useModalFocusRestore } from '@/hooks/useModalFocusRestore';
 import styles from '@/routes/_auth/_user/request.$requestId.module.css';
 import { useUserStore } from '@/stores/userStore';
 import { AddFilesClotureDrawer, type AddFilesClotureDrawerRef } from './AddFilesClotureDrawer';
+import { StepFiles } from './StepFiles';
 import { StepNote } from './StepNote';
+import { formatAgent, formatDate } from './stepFormat';
 
 type StepType = NonNullable<ReturnType<typeof useProcessingSteps>['data']>['data'][number];
 
@@ -30,19 +31,6 @@ type StepProps = StepType & {
   onSendAcknowledgment?: () => void;
   openEdit?(step: StepType): void;
 };
-
-const formatDate = (dateStr: string | Date) =>
-  new Date(dateStr).toLocaleDateString('fr-FR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
-
-const formatAgent = (agent: { prenom: string; nom: string }): React.ReactNode => (
-  <>
-    {capitalizeFirst(agent.prenom)} <span className="lastname">{capitalizeFirst(agent.nom)}</span>
-  </>
-);
 
 const formatStepCreationInfo = (
   createdBy: { prenom: string; nom: string } | null | undefined,
@@ -75,6 +63,7 @@ const getStepSubtitle = (
   createdBy: StepType['createdBy'],
   notes: StepType['notes'],
   requete: StepType['requete'],
+  uploadedFiles: StepType['uploadedFiles'],
   clotureEffectiveDate?: string | null,
   dateRealisation?: string | Date | null,
 ): React.ReactNode => {
@@ -109,6 +98,18 @@ const getStepSubtitle = (
   }
   if (type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT) {
     if (statutId === REQUETE_ETAPE_STATUT_TYPES.FAIT) {
+      // The AR PDF is attached to the step and kept non-deletable (canDelete:false).
+      const arFile = uploadedFiles.find((file) => !file.canDelete);
+      if (arFile?.uploadedBy) {
+        return (
+          <>
+            Envoyé le {formatDate(arFile.createdAt)} par {formatAgent(arFile.uploadedBy)}
+          </>
+        );
+      }
+      if (arFile) {
+        return `Envoyé automatiquement le ${formatDate(arFile.createdAt)}`;
+      }
       const sendNote = notes.find((note) => note.texte?.startsWith("Email d'accusé de réception envoyé le"));
       const isManualRequest = !!requete?.createdBy;
       if (isManualRequest && sendNote?.author) {
@@ -243,6 +244,7 @@ const StepComponent = ({
                   createdBy,
                   notes,
                   requete,
+                  rest.uploadedFiles,
                   clotureEffectiveDate,
                   step.dateRealisation,
                 )}
@@ -322,46 +324,9 @@ const StepComponent = ({
           </>
         ) : (
           <>
-            {sendNote && sendNote.uploadedFiles.length > 0 && (
-              <ul className="fr-mt-1w fr-mb-2w" style={{ listStyle: 'none', padding: 0 }}>
-                {sendNote.uploadedFiles.map((file: (typeof sendNote.uploadedFiles)[number]) => {
-                  const fileName = file.fileName;
-                  return (
-                    <li key={file.id} className={styles['request-note__file']}>
-                      <FileDownloadLink
-                        href={`/api/requete-etapes/${id}/file/${file.id}`}
-                        safeHref={`/api/requete-etapes/${id}/file/${file.id}/safe`}
-                        fileName={fileName}
-                        fileId={file.id}
-                        fileSize={file.size}
-                        status={file.status}
-                        scanStatus={file.scanStatus}
-                        sanitizeStatus={file.sanitizeStatus}
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
             <div className={styles['request-notes']}>
               {displayNotes.slice(0, isOpen ? displayNotes.length : 3).map((note: StepType['notes'][number]) => (
-                <StepNote
-                  key={note.id}
-                  content={note.texte}
-                  author={note.author}
-                  id={note.id}
-                  createdAt={note.createdAt}
-                  files={note.uploadedFiles.map((file: (typeof note.uploadedFiles)[number]) => ({
-                    id: file.id,
-                    size: file.size,
-                    originalName: file.fileName,
-                    status: file.status,
-                    scanStatus: file.scanStatus,
-                    sanitizeStatus: file.sanitizeStatus,
-                  }))}
-                  requeteStateId={id}
-                  clotureReasonLabels={null}
-                />
+                <StepNote key={note.id} content={note.texte} author={note.author} createdAt={note.createdAt} />
               ))}
             </div>
             <div className={styles['request-notes-distplay']}>
@@ -377,6 +342,7 @@ const StepComponent = ({
                 </button>
               )}
             </div>
+            <StepFiles files={rest.uploadedFiles} stepId={id} />
             {canEditStep && (
               <Button
                 className={styles['request-step__add-note']}

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -55,18 +55,31 @@ const getStepTitle = (type: string, statutId: string | null, nom: string | null)
   return nom ?? '';
 };
 
-const getStepSubtitle = (
-  type: string,
-  statutId: string | null,
-  createdAt: string,
-  updatedAt: string,
-  createdBy: StepType['createdBy'],
-  notes: StepType['notes'],
-  requete: StepType['requete'],
-  uploadedFiles: StepType['uploadedFiles'],
-  clotureEffectiveDate?: string | null,
-  dateRealisation?: string | Date | null,
-): React.ReactNode => {
+type StepSubtitleArgs = {
+  type: string;
+  statutId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: StepType['createdBy'];
+  notes: StepType['notes'];
+  requete: StepType['requete'];
+  uploadedFiles: StepType['uploadedFiles'];
+  clotureEffectiveDate?: string | null;
+  dateRealisation?: string | Date | null;
+};
+
+const getStepSubtitle = ({
+  type,
+  statutId,
+  createdAt,
+  updatedAt,
+  createdBy,
+  notes,
+  requete,
+  uploadedFiles,
+  clotureEffectiveDate,
+  dateRealisation,
+}: StepSubtitleArgs): React.ReactNode => {
   if (statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) {
     const agent = createdBy ?? notes[0]?.author;
     const closureDate = clotureEffectiveDate ?? createdAt;
@@ -225,29 +238,22 @@ const StepComponent = ({
             <div className="fr-col">
               <h3 className="fr-h6 fr-mb-0">{getStepTitle(step.type, statutId, nom)}</h3>
             </div>
-            {showAFaireBadge && (
-              <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
-                <p className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--info">
-                  {requeteEtapeStatutType.A_FAIRE}
-                </p>
-              </div>
-            )}
           </div>
           <div className="fr-grid-row fr-grid-row--middle fr-mt-1w">
             <div className="fr-col">
               <p className="fr-text--xs fr-text-mention--grey">
-                {getStepSubtitle(
-                  step.type,
+                {getStepSubtitle({
+                  type: step.type,
                   statutId,
                   createdAt,
                   updatedAt,
                   createdBy,
                   notes,
                   requete,
-                  rest.uploadedFiles,
+                  uploadedFiles: step.uploadedFiles,
                   clotureEffectiveDate,
-                  step.dateRealisation,
-                )}
+                  dateRealisation: step.dateRealisation,
+                })}
               </p>
               {isAcknowledgmentSendable && canEdit && (
                 <div className="fr-mt-2w">
@@ -257,6 +263,13 @@ const StepComponent = ({
                 </div>
               )}
             </div>
+            {showAFaireBadge && (
+              <div className="fr-col-auto" style={{ minWidth: 'fit-content', flexShrink: 0 }}>
+                <p className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--info">
+                  {requeteEtapeStatutType.A_FAIRE}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -342,7 +355,7 @@ const StepComponent = ({
                 </button>
               )}
             </div>
-            <StepFiles files={rest.uploadedFiles} stepId={id} />
+            <StepFiles files={step.uploadedFiles} stepId={id} />
             {canEditStep && (
               <Button
                 className={styles['request-step__add-note']}

--- a/apps/frontend/src/components/requestId/processing/StepFiles.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFiles.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StepFiles } from './StepFiles';
+
+vi.mock('@/components/common/FileDownloadLink', () => ({
+  FileDownloadLink: ({ fileName }: { fileName: string }) => <a href="#test">{fileName}</a>,
+}));
+
+type StepFile = React.ComponentProps<typeof StepFiles>['files'][number];
+
+const makeFile = (overrides: Partial<StepFile> = {}): StepFile =>
+  ({
+    id: 'f',
+    size: 1,
+    fileName: 'f.pdf',
+    status: 'READY',
+    scanStatus: 'CLEAN',
+    sanitizeStatus: 'COMPLETED',
+    canDelete: true,
+    createdAt: '2026-05-19T10:00:00.000Z',
+    uploadedBy: { prenom: 'jeanne', nom: 'Moulon' },
+    ...overrides,
+  }) as StepFile;
+
+describe('StepFiles', () => {
+  it('renders each file as its own card', () => {
+    render(
+      <StepFiles
+        stepId="s"
+        files={[makeFile({ id: 'a', fileName: 'a.pdf' }), makeFile({ id: 'b', fileName: 'b.pdf' })]}
+      />,
+    );
+
+    expect(screen.getAllByText(/Fichier ajouté/)).toHaveLength(2);
+    expect(screen.getByText('a.pdf')).toBeInTheDocument();
+    expect(screen.getByText('b.pdf')).toBeInTheDocument();
+  });
+
+  it('labels a user-uploaded file with its author', () => {
+    render(<StepFiles stepId="s" files={[makeFile({ canDelete: true })]} />);
+
+    expect(screen.getByText(/Fichier ajouté le 19\/05\/2026 par/)).toBeInTheDocument();
+  });
+
+  it('labels a manually-sent AR (an uploader is recorded) with its sender', () => {
+    render(
+      <StepFiles
+        stepId="s"
+        files={[
+          makeFile({
+            canDelete: false,
+            createdAt: '2026-05-20T10:00:00.000Z',
+            uploadedBy: { prenom: 'jeanne', nom: 'Moulon' },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/Fichier ajouté le 20\/05\/2026 par/)).toBeInTheDocument();
+  });
+
+  it('labels a file without an uploader as automatic', () => {
+    render(
+      <StepFiles
+        stepId="s"
+        files={[makeFile({ canDelete: false, createdAt: '2026-05-20T10:00:00.000Z', uploadedBy: null })]}
+      />,
+    );
+
+    expect(screen.getByText(/Fichier ajouté automatiquement le 20\/05\/2026/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/requestId/processing/StepFiles.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFiles.test.tsx
@@ -8,19 +8,18 @@ vi.mock('@/components/common/FileDownloadLink', () => ({
 
 type StepFile = React.ComponentProps<typeof StepFiles>['files'][number];
 
-const makeFile = (overrides: Partial<StepFile> = {}): StepFile =>
-  ({
-    id: 'f',
-    size: 1,
-    fileName: 'f.pdf',
-    status: 'READY',
-    scanStatus: 'CLEAN',
-    sanitizeStatus: 'COMPLETED',
-    canDelete: true,
-    createdAt: '2026-05-19T10:00:00.000Z',
-    uploadedBy: { prenom: 'jeanne', nom: 'Moulon' },
-    ...overrides,
-  }) as StepFile;
+const makeFile = (overrides: Partial<StepFile> = {}): StepFile => ({
+  id: 'f',
+  size: 1,
+  fileName: 'f.pdf',
+  status: 'READY',
+  scanStatus: 'CLEAN',
+  sanitizeStatus: 'COMPLETED',
+  canDelete: true,
+  createdAt: '2026-05-19T10:00:00.000Z',
+  uploadedBy: { prenom: 'jeanne', nom: 'Moulon' },
+  ...overrides,
+});
 
 describe('StepFiles', () => {
   it('renders each file as its own card', () => {

--- a/apps/frontend/src/components/requestId/processing/StepFiles.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFiles.tsx
@@ -1,0 +1,50 @@
+import { FileDownloadLink } from '@/components/common/FileDownloadLink';
+import type { useProcessingSteps } from '@/hooks/queries/processingSteps.hook';
+import styles from '@/routes/_auth/_user/request.$requestId.module.css';
+import { formatAgent, formatDate } from './stepFormat';
+
+type StepFile = NonNullable<ReturnType<typeof useProcessingSteps>['data']>['data'][number]['uploadedFiles'][number];
+
+type StepFilesProps = {
+  files: StepFile[];
+  stepId: string;
+};
+
+export const StepFiles = ({ files, stepId }: StepFilesProps) => {
+  if (files.length === 0) return null;
+
+  return (
+    <div className={styles['step-files']}>
+      {files.map((file) => {
+        const fileName = file.fileName;
+        const author = file.uploadedBy;
+        return (
+          <div key={file.id} className={styles['step-file']}>
+            <p className={styles['step-file__from']}>
+              <span className="fr-icon-attachment-line fr-icon--xs" aria-hidden="true" /> Fichier ajouté{' '}
+              {author ? (
+                <>
+                  le {formatDate(file.createdAt)} par <span className="fr-text--bold">{formatAgent(author)}</span>
+                </>
+              ) : (
+                <>automatiquement le {formatDate(file.createdAt)}</>
+              )}
+            </p>
+            <div className={styles['request-note__file']}>
+              <FileDownloadLink
+                href={`/api/requete-etapes/${stepId}/file/${file.id}`}
+                safeHref={`/api/requete-etapes/${stepId}/file/${file.id}/safe`}
+                fileName={fileName}
+                fileId={file.id}
+                fileSize={file.size}
+                status={file.status}
+                scanStatus={file.scanStatus}
+                sanitizeStatus={file.sanitizeStatus}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/requestId/processing/StepFiles.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFiles.tsx
@@ -24,7 +24,7 @@ export const StepFiles = ({ files, stepId }: StepFilesProps) => {
               <span className="fr-icon-attachment-line fr-icon--xs" aria-hidden="true" /> Fichier ajouté{' '}
               {author ? (
                 <>
-                  le {formatDate(file.createdAt)} par <span className="fr-text--bold">{formatAgent(author)}</span>
+                  le {formatDate(file.createdAt)} par {formatAgent(author)}
                 </>
               ) : (
                 <>automatiquement le {formatDate(file.createdAt)}</>

--- a/apps/frontend/src/components/requestId/processing/StepNote.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepNote.tsx
@@ -1,43 +1,27 @@
 import clsx from 'clsx';
-import { FileDownloadLink } from '@/components/common/FileDownloadLink';
 import { capitalizeFirst } from '@/components/requestId/sections/helpers';
 import styles from '@/routes/_auth/_user/request.$requestId.module.css';
 
 type StepNoteProps = {
-  id: string;
   content: string;
   createdAt: string;
-  requeteStateId: string;
-  clotureReasonLabels: string[] | null;
   author?: {
     prenom: string;
     nom: string;
   } | null;
-  files: {
-    id: string;
-    size: number;
-    originalName: string;
-    status?: string;
-    scanStatus?: string;
-    sanitizeStatus?: string;
-    safeFilePath?: string | null;
-  }[];
 };
 
-export const StepNote = ({ author, content, createdAt, requeteStateId, files, clotureReasonLabels }: StepNoteProps) => {
+export const StepNote = ({ author, content, createdAt }: StepNoteProps) => {
   return (
     <div className={styles['request-note']}>
       <div className="fr-grid-row fr-grid-row--middle fr-mb-1v">
         <p className={clsx('fr-col fr-mb-0', styles['request-note__from'])}>
-          Le
-          <span>
-            {' '}
-            {new Date(createdAt).toLocaleDateString('fr-FR', {
-              day: '2-digit',
-              month: '2-digit',
-              year: 'numeric',
-            })}{' '}
-          </span>
+          <span className="fr-icon-draft-line fr-icon--xs" aria-hidden="true" /> Note rédigée le{' '}
+          {new Date(createdAt).toLocaleDateString('fr-FR', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+          })}{' '}
           {author && (
             <>
               <span>par </span>
@@ -48,41 +32,9 @@ export const StepNote = ({ author, content, createdAt, requeteStateId, files, cl
           )}
         </p>
       </div>
-      {clotureReasonLabels && (
-        <div>
-          <div className="fr-text--xs fr-mb-0">Raisons de la clôture</div>
-          <ul className="fr-text--sm fr-text--grey fr-mt-1v fr-mb-0">
-            {clotureReasonLabels.map((label) => (
-              <li key={label}>{label}</li>
-            ))}
-          </ul>
-        </div>
-      )}
       {content && (
-        <div className="fr-mb-2w">
-          {clotureReasonLabels && <div className="fr-text--xs fr-mb-0">Précisions</div>}
-          <p className="fr-text--sm fr-text--grey">{content}</p>
-        </div>
-      )}
-      {files.length > 0 && (
         <div>
-          <div className="fr-text--xs fr-mb-0">Pièces jointes</div>
-          <ul>
-            {files.map((file) => (
-              <li key={file.id} className={styles['request-note__file']}>
-                <FileDownloadLink
-                  href={`/api/requete-etapes/${requeteStateId}/file/${file.id}`}
-                  safeHref={`/api/requete-etapes/${requeteStateId}/file/${file.id}/safe`}
-                  fileName={file.originalName}
-                  fileId={file.id}
-                  fileSize={file.size}
-                  status={file.status}
-                  scanStatus={file.scanStatus}
-                  sanitizeStatus={file.sanitizeStatus}
-                />
-              </li>
-            ))}
-          </ul>
+          <p className="fr-text--sm fr-text--grey fr-mb-0">{content}</p>
         </div>
       )}
     </div>

--- a/apps/frontend/src/components/requestId/processing/StepNote.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepNote.tsx
@@ -1,6 +1,6 @@
-import clsx from 'clsx';
-import { capitalizeFirst } from '@/components/requestId/sections/helpers';
+import { clsx } from 'clsx';
 import styles from '@/routes/_auth/_user/request.$requestId.module.css';
+import { formatAgent, formatDate } from './stepFormat';
 
 type StepNoteProps = {
   content: string;
@@ -16,20 +16,8 @@ export const StepNote = ({ author, content, createdAt }: StepNoteProps) => {
     <div className={styles['request-note']}>
       <div className="fr-grid-row fr-grid-row--middle fr-mb-1v">
         <p className={clsx('fr-col fr-mb-0', styles['request-note__from'])}>
-          <span className="fr-icon-draft-line fr-icon--xs" aria-hidden="true" /> Note rédigée le{' '}
-          {new Date(createdAt).toLocaleDateString('fr-FR', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric',
-          })}{' '}
-          {author && (
-            <>
-              <span>par </span>
-              <span className="fr-text--bold">
-                {capitalizeFirst(author.prenom)} <span className="lastname">{author.nom}</span>
-              </span>
-            </>
-          )}
+          <span className="fr-icon-draft-line fr-icon--xs" aria-hidden="true" /> Note rédigée le {formatDate(createdAt)}
+          {author && <> par {formatAgent(author)}</>}
         </p>
       </div>
       {content && (

--- a/apps/frontend/src/components/requestId/processing/stepFormat.tsx
+++ b/apps/frontend/src/components/requestId/processing/stepFormat.tsx
@@ -1,0 +1,14 @@
+import { capitalizeFirst } from '@/components/requestId/sections/helpers';
+
+export const formatDate = (dateStr: string | Date) =>
+  new Date(dateStr).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+
+export const formatAgent = (agent: { prenom: string; nom: string }): React.ReactNode => (
+  <>
+    {capitalizeFirst(agent.prenom)} <span className="lastname">{capitalizeFirst(agent.nom)}</span>
+  </>
+);

--- a/apps/frontend/src/routes/_auth/_user/request.$requestId.module.css
+++ b/apps/frontend/src/routes/_auth/_user/request.$requestId.module.css
@@ -113,6 +113,27 @@
   color: var(--text-action-high-blue-france);
 }
 
+.step-files {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.step-file {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--border-default-grey);
+  border-radius: 0.25rem;
+}
+
+.step-file__from {
+  font-size: 0.8rem;
+  margin-bottom: 0;
+}
+
 .timeline-step:last-child .request-step {
   border-bottom: none;
 }


### PR DESCRIPTION
## Objectif
PR8 du chantier SIRENA-635/636 — refonte de l'affichage de la timeline des étapes de traitement. Front uniquement 

## Changements
- **Fichiers au niveau étape** : nouveau composant `StepFiles`. Chaque fichier de `step.uploadedFiles` est rendu comme un **événement de timeline** 
- **Label fichier** piloté par `uploadedBy` : « Fichier ajouté le … par {agent} » si un auteur est enregistré (upload manuel, ou AR envoyé manuellement), sinon « Fichier ajouté automatiquement le … » (AR automatique).
- **Sous-titre AR** dérivé du **fichier AR** (`canDelete:false`) au lieu de l'ancienne note système : « Envoyé le … par … » (manuel) / « Envoyé automatiquement le … » (auto).
- **`StepNote`** devient purement texte : en-tête « Note rédigée le … par … » + contenu. Suppression de l'affichage des PJ sous la note et du code mort

