### PR TITLE
SIRENA-647 - empêche la disparition du lien Indicateurs/Requêtes après inactivité

### DIFF
--- a/apps/frontend/src/hooks/queries/featureFlags.hook.test.tsx
+++ b/apps/frontend/src/hooks/queries/featureFlags.hook.test.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchResolvedFeatureFlags } from '@/lib/api/fetchFeatureFlags';
+import { useFeatureFlagStore } from '@/stores/featureFlagStore';
+import { useResolvedFeatureFlags } from './featureFlags.hook';
+
+vi.mock('@/lib/api/fetchFeatureFlags', () => ({
+  fetchResolvedFeatureFlags: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(fetchResolvedFeatureFlags);
+
+const createWrapper = (client: QueryClient) => {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useResolvedFeatureFlags', () => {
+  beforeEach(() => {
+    useFeatureFlagStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('populates the store with resolved flags on success', async () => {
+    mockedFetch.mockResolvedValueOnce({ STATISTICS: true });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useResolvedFeatureFlags(), { wrapper: createWrapper(client) });
+
+    await waitFor(() => {
+      expect(useFeatureFlagStore.getState().flags).toEqual({ STATISTICS: true });
+    });
+  });
+
+  it('keeps previously resolved flags when a refetch fails', async () => {
+    mockedFetch.mockResolvedValueOnce({ STATISTICS: true }).mockRejectedValueOnce(new Error('network error'));
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useResolvedFeatureFlags(), { wrapper: createWrapper(client) });
+
+    await waitFor(() => {
+      expect(useFeatureFlagStore.getState().flags).toEqual({ STATISTICS: true });
+    });
+
+    await result.current.refetch().catch(() => {});
+
+    await waitFor(() => {
+      expect(mockedFetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(useFeatureFlagStore.getState().flags).toEqual({ STATISTICS: true });
+  });
+});

--- a/apps/frontend/src/hooks/queries/featureFlags.hook.ts
+++ b/apps/frontend/src/hooks/queries/featureFlags.hook.ts
@@ -13,18 +13,15 @@ export const useResolvedFeatureFlags = () => {
   const query = useQuery({
     queryKey: ['featureFlags', 'resolved'],
     queryFn: fetchResolvedFeatureFlags,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
   });
 
   const setFlags = useFeatureFlagStore((s) => s.setFlags);
-  const reset = useFeatureFlagStore((s) => s.reset);
 
   useEffect(() => {
     if (query.data) setFlags(query.data);
   }, [query.data, setFlags]);
-
-  useEffect(() => {
-    if (query.isError) reset();
-  }, [query.isError, reset]);
 
   return query;
 };


### PR DESCRIPTION
Sur la page Indicateurs, après avoir laissé la page inactive ou en veille un certain temps, le lien du bandeau permettant de revenir vers la liste des requêtes (ou inversement d'aller vers les Indicateurs) disparaissait. Il fallait recharger la page pour le faire réapparaître.

Le lien du header est conditionné par le feature flag STATISTICS lu depuis le store, alimenté par la query useResolvedFeatureFlags.

La query n'avait pas de staleTime (donc toujours "stale") et héritait du défaut refetchOnWindowFocus: true. Au retour du focus après une veille, un refetch était déclenché ; avec retry: false, le moindre échec transitoire (réseau pas prêt au réveil, race pendant la rotation du cookie d'auth) suffisait à faire passer la query en erreur. Or le hook appelait reset() sur n'importe quelle erreur, vidant tous les flags → le lien disparaissait, sans récupération automatique jusqu'à un rechargement complet.

Dans useResolvedFeatureFlags :
- Suppression du reset() sur erreur de query. TanStack conserve déjà la dernière donnée connue ; on garde donc le dernier état des flags plutôt que de tout effacer sur un échec transitoire.
- Ajout d'un staleTime de 5 min (les flags changent rarement).
- Désactivation de refetchOnWindowFocus pour cette query.

Le vrai cas de perte d'accès (401) reste géré comme avant dans handleRequestErrors (logout() + reset() + redirection vers /login).