### PR TITLE
feat: remove statistics feature flag

### DIFF
--- a/apps/frontend/src/components/layout/header.tsx
+++ b/apps/frontend/src/components/layout/header.tsx
@@ -1,8 +1,7 @@
 import { Header } from '@codegouvfr/react-dsfr/Header';
-import { FEATURE_FLAGS, ROLES_READ, type Role } from '@sirena/common/constants';
+import { ROLES_READ, type Role } from '@sirena/common/constants';
 import { Link, useLocation } from '@tanstack/react-router';
 import { useId } from 'react';
-import { useFeatureFlagStore } from '@/stores/featureFlagStore';
 import { useUserStore } from '@/stores/userStore';
 import style from './header.module.css';
 import { UserMenu } from './userMenu';
@@ -20,10 +19,9 @@ export const HeaderMenu = (props: HeaderMenuProps) => {
   const id = useId();
   const userStore = useUserStore();
   const { pathname } = useLocation();
-  const isStatisticsEnabled = useFeatureFlagStore((s) => s.flags[FEATURE_FLAGS.STATISTICS] ?? false);
 
   const canAccessRequests = userStore.role != null && (ROLES_READ as readonly Role[]).includes(userStore.role);
-  const showStatisticsLink = userStore.isLogged && isStatisticsEnabled && canAccessRequests;
+  const showStatisticsLink = userStore.isLogged && canAccessRequests;
   const isOnStatistics = pathname === '/statistiques';
 
   const statisticsLink = !showStatisticsLink ? null : isOnStatistics ? (

--- a/apps/frontend/src/hooks/queries/featureFlags.hook.test.tsx
+++ b/apps/frontend/src/hooks/queries/featureFlags.hook.test.tsx
@@ -28,24 +28,24 @@ describe('useResolvedFeatureFlags', () => {
   });
 
   it('populates the store with resolved flags on success', async () => {
-    mockedFetch.mockResolvedValueOnce({ STATISTICS: true });
+    mockedFetch.mockResolvedValueOnce({ UPDATE_BANNER: true });
 
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     renderHook(() => useResolvedFeatureFlags(), { wrapper: createWrapper(client) });
 
     await waitFor(() => {
-      expect(useFeatureFlagStore.getState().flags).toEqual({ STATISTICS: true });
+      expect(useFeatureFlagStore.getState().flags).toEqual({ UPDATE_BANNER: true });
     });
   });
 
   it('keeps previously resolved flags when a refetch fails', async () => {
-    mockedFetch.mockResolvedValueOnce({ STATISTICS: true }).mockRejectedValueOnce(new Error('network error'));
+    mockedFetch.mockResolvedValueOnce({ UPDATE_BANNER: true }).mockRejectedValueOnce(new Error('network error'));
 
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const { result } = renderHook(() => useResolvedFeatureFlags(), { wrapper: createWrapper(client) });
 
     await waitFor(() => {
-      expect(useFeatureFlagStore.getState().flags).toEqual({ STATISTICS: true });
+      expect(useFeatureFlagStore.getState().flags).toEqual({ UPDATE_BANNER: true });
     });
 
     await result.current.refetch().catch(() => {});
@@ -54,6 +54,6 @@ describe('useResolvedFeatureFlags', () => {
       expect(mockedFetch).toHaveBeenCalledTimes(2);
     });
 
-    expect(useFeatureFlagStore.getState().flags).toEqual({ STATISTICS: true });
+    expect(useFeatureFlagStore.getState().flags).toEqual({ UPDATE_BANNER: true });
   });
 });

--- a/apps/frontend/src/routes/_auth/_user/statistiques.tsx
+++ b/apps/frontend/src/routes/_auth/_user/statistiques.tsx
@@ -1,5 +1,5 @@
 import { fr } from '@codegouvfr/react-dsfr';
-import { FEATURE_FLAGS, ROLES_READ } from '@sirena/common/constants';
+import { ROLES_READ } from '@sirena/common/constants';
 import { createFileRoute, Navigate, useNavigate, useSearch } from '@tanstack/react-router';
 import type { CSSProperties } from 'react';
 import { z } from 'zod';
@@ -10,7 +10,6 @@ import { PeriodFilter } from '@/components/statistics/PeriodFilter';
 import { describePeriod, PERIOD_PRESETS, type PeriodSelection, resolveDateRange } from '@/components/statistics/period';
 import { StatChart } from '@/components/statistics/StatChart';
 import { StatTable } from '@/components/statistics/StatTable';
-import { useResolvedFeatureFlags } from '@/hooks/queries/featureFlags.hook';
 import { useProfile } from '@/hooks/queries/profile.hook';
 import { useStatisticsDashboard } from '@/hooks/queries/statistics.hook';
 import type { StatisticsCard } from '@/lib/api/fetchStatistics';
@@ -119,22 +118,19 @@ function ChartCard({ card }: { card: StatisticsCard }) {
 }
 
 function RouteComponent() {
-  const resolvedFlagsQuery = useResolvedFeatureFlags();
   const { data: profile, isPending: isProfilePending } = useProfile();
   const search = useSearch({ from: '/_auth/_user/statistiques' });
   const navigate = useNavigate({ from: '/statistiques' });
 
   const hasEntityLink = profile?.entiteId != null;
 
-  const areFlagsReady = resolvedFlagsQuery.status !== 'pending';
-  const isEnabled = resolvedFlagsQuery.data?.[FEATURE_FLAGS.STATISTICS] ?? false;
   const selection: PeriodSelection = {
     period: search.period,
     startDate: search.startDate,
     endDate: search.endDate,
   };
   const range = resolveDateRange(selection, new Date());
-  const query = useStatisticsDashboard(range, areFlagsReady && isEnabled && hasEntityLink);
+  const query = useStatisticsDashboard(range, hasEntityLink);
 
   const handlePeriodChange = (next: PeriodSelection) => {
     navigate({
@@ -142,10 +138,10 @@ function RouteComponent() {
     });
   };
 
-  if (isProfilePending || !areFlagsReady) {
+  if (isProfilePending) {
     return null;
   }
-  if (!isEnabled || !hasEntityLink) {
+  if (!hasEntityLink) {
     return <Navigate to="/home" />;
   }
 

--- a/packages/common/src/constants/featureFlag.constant.ts
+++ b/packages/common/src/constants/featureFlag.constant.ts
@@ -1,8 +1,6 @@
 export const FEATURE_FLAGS = {
   //definitive FF : will be used to disable/enable update banner following PO decisions
   UPDATE_BANNER: 'UPDATE_BANNER',
-  // temporary FF to enable/disable statistics page for all users
-  STATISTICS: 'STATISTICS',
   // Email-targeted FF for the SIREC migration admin screen
   SIREC_MIGRATION: 'SIREC_MIGRATION',
 } as const;


### PR DESCRIPTION
The statistics page is now always enabled when the user has access to it