### PR TITLE
fix: harden multi-file upload in CloseRequeteModal against unhandled rejection

### DIFF
--- a/apps/frontend/src/components/requestId/processing/CloseRequeteModal.tsx
+++ b/apps/frontend/src/components/requestId/processing/CloseRequeteModal.tsx
@@ -175,11 +175,15 @@ export const CloseRequeteModal = forwardRef<CloseRequeteModalRef, CloseRequeteMo
 
         let fileIds: string[] = [];
         if (files.length > 0) {
-          const uploadPromises = files.map(async (file) => {
-            const response = await uploadFileMutation.mutateAsync(file);
-            return response.id;
-          });
-          fileIds = await Promise.all(uploadPromises);
+          const uploads = await Promise.allSettled(files.map((file) => uploadFileMutation.mutateAsync(file)));
+          const ids: string[] = [];
+          for (const upload of uploads) {
+            if (upload.status === 'rejected') {
+              throw upload.reason;
+            }
+            ids.push(upload.value.id);
+          }
+          fileIds = ids;
         }
 
         await closeRequeteMutation.mutateAsync({


### PR DESCRIPTION
Switch the attachment upload fan-out from Promise.all to Promise.allSettled so every upload promise is locally settled. On failure the first rejection is re-thrown into the existing try/catch (user still sees the error message), but no orphan rejection can reach the global onunhandledrejection handler.

Ref: Sentry PSN-SIRENA-FRONTEND-M2-29 / -2R (500 on POST /uploaded-files)