### PR TITLE
feat(frontend): prompt refresh on Vite preload error instead of crashing

### DIFF
--- a/apps/frontend/src/components/AppUpdateNotice.test.tsx
+++ b/apps/frontend/src/components/AppUpdateNotice.test.tsx
@@ -25,7 +25,7 @@ describe('AppUpdateNotice', () => {
     useAppUpdateStore.setState({ isUpdateAvailable: true });
     render(<AppUpdateNotice />);
 
-    expect(screen.getByText(/nouvelle version de l'application/i)).toBeInTheDocument();
+    expect(screen.getByText(/votre version de sirena chargée sur votre navigateur diffère/i)).toBeInTheDocument();
     expect(reload).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getByRole('button', { name: /rafraîchir/i }));

--- a/apps/frontend/src/components/AppUpdateNotice.test.tsx
+++ b/apps/frontend/src/components/AppUpdateNotice.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAppUpdateStore } from '@/stores/appUpdateStore';
+import { AppUpdateNotice } from './AppUpdateNotice';
+
+describe('AppUpdateNotice', () => {
+  afterEach(() => {
+    useAppUpdateStore.setState({ isUpdateAvailable: false });
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing while no update is available', () => {
+    const { container } = render(<AppUpdateNotice />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('prompts to refresh and reloads only when the user clicks', async () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    useAppUpdateStore.setState({ isUpdateAvailable: true });
+    render(<AppUpdateNotice />);
+
+    expect(screen.getByText(/nouvelle version de l'application/i)).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: /rafraîchir/i }));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be dismissed without reloading', async () => {
+    useAppUpdateStore.setState({ isUpdateAvailable: true });
+    render(<AppUpdateNotice />);
+
+    await userEvent.click(screen.getByRole('button', { name: /masquer/i }));
+
+    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(false);
+  });
+});

--- a/apps/frontend/src/components/AppUpdateNotice.tsx
+++ b/apps/frontend/src/components/AppUpdateNotice.tsx
@@ -19,7 +19,8 @@ export function AppUpdateNotice() {
       onClose={dismiss}
       title={
         <>
-          Une nouvelle version de l'application est disponible.
+          Votre version de Sirena chargée sur votre navigateur diffère de celle en ligne actuellement. Pour éviter tout
+          problème, nous vous conseillons de recharger la page.
           <Button priority="secondary" size="small" className="fr-ml-2w" onClick={reloadPage}>
             Rafraîchir la page
           </Button>

--- a/apps/frontend/src/components/AppUpdateNotice.tsx
+++ b/apps/frontend/src/components/AppUpdateNotice.tsx
@@ -1,0 +1,30 @@
+import Button from '@codegouvfr/react-dsfr/Button';
+import { Notice } from '@codegouvfr/react-dsfr/Notice';
+import { useAppUpdateStore } from '@/stores/appUpdateStore';
+
+const reloadPage = () => window.location.reload();
+
+export function AppUpdateNotice() {
+  const isUpdateAvailable = useAppUpdateStore((state) => state.isUpdateAvailable);
+  const dismiss = useAppUpdateStore((state) => state.dismiss);
+
+  if (!isUpdateAvailable) {
+    return null;
+  }
+
+  return (
+    <Notice
+      severity="info"
+      isClosable
+      onClose={dismiss}
+      title={
+        <>
+          Une nouvelle version de l'application est disponible.
+          <Button priority="secondary" size="small" className="fr-ml-2w" onClick={reloadPage}>
+            Rafraîchir la page
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/apps/frontend/src/lib/preloadError.test.ts
+++ b/apps/frontend/src/lib/preloadError.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { useAppUpdateStore } from '@/stores/appUpdateStore';
+import { registerPreloadErrorHandler } from './preloadError';
+
+describe('registerPreloadErrorHandler', () => {
+  afterEach(() => {
+    useAppUpdateStore.setState({ isUpdateAvailable: false });
+  });
+
+  it('flags an update and prevents the default when a preload error fires', () => {
+    registerPreloadErrorHandler();
+
+    const event = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(true);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('registers the listener only once', () => {
+    registerPreloadErrorHandler();
+    registerPreloadErrorHandler();
+
+    const event = new Event('vite:preloadError', { cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(true);
+  });
+});

--- a/apps/frontend/src/lib/preloadError.test.ts
+++ b/apps/frontend/src/lib/preloadError.test.ts
@@ -1,29 +1,92 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useAppUpdateStore } from '@/stores/appUpdateStore';
 import { registerPreloadErrorHandler } from './preloadError';
+
+const CHUNK_URL = 'https://app.test/assets/index-abc123.js';
+
+function dispatchPreloadError(payload?: unknown): Event {
+  const event = new Event('vite:preloadError', { cancelable: true }) as Event & { payload?: unknown };
+  event.payload = payload;
+  window.dispatchEvent(event);
+  return event;
+}
+
+function preloadError(url = CHUNK_URL): Error {
+  return new Error(`Failed to fetch dynamically imported module: ${url}`);
+}
 
 describe('registerPreloadErrorHandler', () => {
   afterEach(() => {
     useAppUpdateStore.setState({ isUpdateAvailable: false });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
-  it('flags an update and prevents the default when a preload error fires', () => {
+  it('flags an update when the failing asset is gone (404 = stale deploy)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
     registerPreloadErrorHandler();
 
-    const event = new Event('vite:preloadError', { cancelable: true });
-    window.dispatchEvent(event);
+    const event = dispatchPreloadError(preloadError());
 
-    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(true);
     expect(event.defaultPrevented).toBe(true);
+    await vi.waitFor(() => expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(true));
+    expect(fetch).toHaveBeenCalledWith(CHUNK_URL, expect.objectContaining({ method: 'HEAD', cache: 'no-store' }));
   });
 
-  it('registers the listener only once', () => {
-    registerPreloadErrorHandler();
+  it('stays silent when the asset still resolves (200 = network blip)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
     registerPreloadErrorHandler();
 
-    const event = new Event('vite:preloadError', { cancelable: true });
-    window.dispatchEvent(event);
+    const event = dispatchPreloadError(preloadError());
 
+    expect(event.defaultPrevented).toBe(true);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(false);
+  });
+
+  it('stays silent when the server is unreachable (fetch rejects)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    registerPreloadErrorHandler();
+
+    dispatchPreloadError(preloadError());
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(false);
+  });
+
+  it('stays silent and skips the probe when offline', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+    registerPreloadErrorHandler();
+
+    dispatchPreloadError(preloadError());
+
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(false);
+  });
+
+  it('surfaces the notice conservatively when no asset URL can be extracted', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    registerPreloadErrorHandler();
+
+    const event = dispatchPreloadError(new Error('boom without any url'));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(true);
+  });
+
+  it('registers the listener only once', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+    registerPreloadErrorHandler();
+    registerPreloadErrorHandler();
+
+    dispatchPreloadError(preloadError());
+
+    await vi.waitFor(() => expect(useAppUpdateStore.getState().isUpdateAvailable).toBe(true));
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/frontend/src/lib/preloadError.ts
+++ b/apps/frontend/src/lib/preloadError.ts
@@ -2,15 +2,54 @@ import { useAppUpdateStore } from '@/stores/appUpdateStore';
 
 let isRegistered = false;
 
+const ASSET_URL_RE = /(https?:\/\/[^\s'")]+|\/[^\s'")]+\.(?:m?js|css))/;
+const PROBE_TIMEOUT_MS = 5000;
+
+/** Vite dispatches `vite:preloadError` with the underlying error as `payload`. */
+type PreloadErrorEvent = Event & { payload?: unknown };
+
+function extractAssetUrl(payload: unknown): string | null {
+  if (!(payload instanceof Error)) {
+    return null;
+  }
+  const match = payload.message.match(ASSET_URL_RE);
+  return match ? match[0] : null;
+}
+
 /**
- * After a deployment, a long-lived session still references content-hashed
- * chunks/CSS from the previous release that no longer exist on the server, so
- * Vite dispatches `vite:preloadError`. With `defaultPreload: 'intent'` this can
- * also fire from a background hover-preload, without any navigation.
+ * A `vite:preloadError` fires for two very different reasons:
+ *  1. a deploy removed the content-hashed chunk this session still points at
+ *     (nginx serves `/assets/` with `try_files $uri =404`, so a stale chunk
+ *     yields a hard 404) — a refresh fixes it;
+ *  2. a transient network failure (offline, flaky connection) — a refresh does
+ *     NOT help and would needlessly risk discarding an in-progress form.
  *
+ * We probe the failing asset to tell them apart: only a genuine 404 (the file
+ * is gone from the server) means a new release shipped. Any other outcome — the
+ * asset still resolves, or the server is unreachable — is treated as a network
+ * blip and stays silent.
+ */
+async function isStaleDeploy(url: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return false;
+  }
+  try {
+    const res = await fetch(url, {
+      method: 'HEAD',
+      cache: 'no-store',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return res.status === 404;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * We suppress the throw (which otherwise surfaces as an ErrorBoundary crash and
- * Sentry noise) and flag that a refresh is available. We deliberately do NOT
- * reload automatically: a reload here would discard an in-progress form. The UI
+ * Sentry noise) unconditionally, then flag that a refresh is available only when
+ * the failure is confirmed to be a stale deploy. We deliberately do NOT reload
+ * automatically: a reload here would discard an in-progress form. The UI
  * surfaces a non-blocking notice and lets the user refresh when they are ready.
  */
 export function registerPreloadErrorHandler(): void {
@@ -21,6 +60,19 @@ export function registerPreloadErrorHandler(): void {
 
   window.addEventListener('vite:preloadError', (event) => {
     event.preventDefault();
-    useAppUpdateStore.getState().notifyUpdateAvailable();
+
+    const url = extractAssetUrl((event as PreloadErrorEvent).payload);
+    if (!url) {
+      // No identifiable asset to probe: surface the notice conservatively. The
+      // notice alone never discards a form — only the user's refresh click does.
+      useAppUpdateStore.getState().notifyUpdateAvailable();
+      return;
+    }
+
+    void isStaleDeploy(url).then((stale) => {
+      if (stale) {
+        useAppUpdateStore.getState().notifyUpdateAvailable();
+      }
+    });
   });
 }

--- a/apps/frontend/src/lib/preloadError.ts
+++ b/apps/frontend/src/lib/preloadError.ts
@@ -1,0 +1,26 @@
+import { useAppUpdateStore } from '@/stores/appUpdateStore';
+
+let isRegistered = false;
+
+/**
+ * After a deployment, a long-lived session still references content-hashed
+ * chunks/CSS from the previous release that no longer exist on the server, so
+ * Vite dispatches `vite:preloadError`. With `defaultPreload: 'intent'` this can
+ * also fire from a background hover-preload, without any navigation.
+ *
+ * We suppress the throw (which otherwise surfaces as an ErrorBoundary crash and
+ * Sentry noise) and flag that a refresh is available. We deliberately do NOT
+ * reload automatically: a reload here would discard an in-progress form. The UI
+ * surfaces a non-blocking notice and lets the user refresh when they are ready.
+ */
+export function registerPreloadErrorHandler(): void {
+  if (isRegistered) {
+    return;
+  }
+  isRegistered = true;
+
+  window.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault();
+    useAppUpdateStore.getState().notifyUpdateAvailable();
+  });
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -4,6 +4,8 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { Link, type LinkProps, RouterProvider } from '@tanstack/react-router';
 import { type JSX, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { AppUpdateNotice } from '@/components/AppUpdateNotice';
+import { registerPreloadErrorHandler } from '@/lib/preloadError';
 import { queryClient } from '@/lib/queryClient';
 import { router } from '@/lib/router';
 import { toastManager } from '@/lib/toastManager';
@@ -26,6 +28,7 @@ declare module '@codegouvfr/react-dsfr/spa' {
 
 startReactDsfr({ defaultColorScheme: 'system', Link });
 initMatomo();
+registerPreloadErrorHandler();
 
 function App() {
   return <RouterProvider router={router} />;
@@ -44,6 +47,7 @@ createRoot(document.getElementById('root') as HTMLElement, {
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <Toast.Provider limit={Infinity} toastManager={toastManager}>
+        <AppUpdateNotice />
         <App />
         <Toast.Portal container={document.body}>
           <Toast.Viewport className="toast-list__viewport">

--- a/apps/frontend/src/stores/appUpdateStore.ts
+++ b/apps/frontend/src/stores/appUpdateStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type AppUpdateState = {
+  isUpdateAvailable: boolean;
+  notifyUpdateAvailable: () => void;
+  dismiss: () => void;
+};
+
+export const useAppUpdateStore = create<AppUpdateState>((set) => ({
+  isUpdateAvailable: false,
+  notifyUpdateAvailable: () => set({ isUpdateAvailable: true }),
+  dismiss: () => set({ isUpdateAvailable: false }),
+}));


### PR DESCRIPTION
After a deployment, a long-lived session references hashed chunks/CSS from the previous release that no longer exist, so Vite dispatches vite:preloadError (also fired by TanStack Router intent hover-preloading). Previously this bubbled to an ErrorBoundary and Sentry.

Add a handler that suppresses the throw and flags an available update, plus a dismissible DSFR Notice offering an explicit 'Rafraîchir la page' action. The page is never reloaded automatically, so an in-progress form is preserved.

Ref: Sentry PSN-SIRENA-FRONTEND-M2-2P (Unable to preload CSS)