### PR TITLE
[SIRENA-644] feat: add endpoint to fetch requetes counts by statut

### DIFF
--- a/apps/backend/src/features/requetesEntite/requetesEntite.controller.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.controller.ts
@@ -49,6 +49,7 @@ import {
   getRequetesDepartementCountsRoute,
   getRequetesDomaineCountsRoute,
   getRequetesEntiteRoute,
+  getRequetesStatutCountsRoute,
   reopenRequeteRoute,
   updateStatutRoute,
 } from './requetesEntite.route.js';
@@ -58,6 +59,7 @@ import {
   GetDepartementCountsQuerySchema,
   GetDomaineCountsQuerySchema,
   GetRequetesEntiteQuerySchema,
+  GetStatutCountsQuerySchema,
   UpdateDeclarantBodySchema,
   UpdateParticipantBodySchema,
   UpdatePrioriteBodySchema,
@@ -78,6 +80,7 @@ import {
   getRequeteEntiteById,
   getRequetesCountsByDepartement,
   getRequetesCountsByDomaine,
+  getRequetesCountsByStatut,
   getRequetesEntite,
   hasAccessToRequete,
   reopenRequeteForEntite,
@@ -144,6 +147,26 @@ const app = factoryWithLogs
       return c.json({ data });
     },
   )
+
+  .get('/statut-counts', getRequetesStatutCountsRoute, zValidator('query', GetStatutCountsQuerySchema), async (c) => {
+    const query = c.req.valid('query');
+    const topEntiteId = c.get('topEntiteId');
+    if (!topEntiteId) {
+      throwHTTPException400BadRequest('You are not allowed to read requetes without topEntiteId.', {
+        res: c.res,
+        kind: ERROR_KIND.BUSINESS,
+      });
+    }
+    const ids = query.statutIds
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean);
+    const data = await getRequetesCountsByStatut([topEntiteId], ids, {
+      search: query.search,
+      entiteId: query.entiteId,
+    });
+    return c.json({ data });
+  })
 
   .get('/', getRequetesEntiteRoute, zValidator('query', GetRequetesEntiteQuerySchema), async (c) => {
     const logger = c.get('logger');

--- a/apps/backend/src/features/requetesEntite/requetesEntite.route.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.route.ts
@@ -46,6 +46,17 @@ export const getRequetesDomaineCountsRoute = openApiProtectedRoute({
   },
 });
 
+export const getRequetesStatutCountsRoute = openApiProtectedRoute({
+  description: 'Get requetes counts grouped by statut',
+  responses: {
+    ...openApiResponse(
+      z.object({
+        data: z.array(z.object({ id: z.string(), count: z.number() })),
+      }),
+    ),
+  },
+});
+
 export const getOtherEntitesAffectedRoute = openApiProtectedRoute({
   description: 'Get other entites affected by the requete',
   responses: {

--- a/apps/backend/src/features/requetesEntite/requetesEntite.schema.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.schema.ts
@@ -71,6 +71,17 @@ export const GetDomaineCountsQuerySchema = z.object({
   search: z.string().max(SEARCH_MAX).optional(),
 });
 
+export const GetStatutCountsQuerySchema = z.object({
+  statutIds: z
+    .string()
+    .max(CSV_FILTER_MAX)
+    .refine((value) => splitCsv(value).every((id) => REQUETE_STATUT_IDS.includes(id)), {
+      message: 'Statut(s) invalide(s)',
+    }),
+  entiteId: z.string().optional(),
+  search: z.string().max(SEARCH_MAX).optional(),
+});
+
 export const GetRequeteEntiteResponseSchema = RequeteSchema.extend({
   entite: EntiteSchema,
 });

--- a/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
+++ b/apps/backend/src/features/requetesEntite/requetesEntite.service.ts
@@ -405,6 +405,21 @@ export const getRequetesCountsByDomaine = async (
   return results;
 };
 
+export const getRequetesCountsByStatut = async (
+  entiteIds: string[] | null,
+  statutIds: string[],
+  baseQuery: { search?: string; entiteId?: string },
+) => {
+  const results = await Promise.all(
+    statutIds.map(async (id) => {
+      const where = await buildRequetesEntiteWhere(entiteIds, { ...baseQuery, statutIds: id });
+      const count = await prisma.requeteEntite.count({ where });
+      return { id, count };
+    }),
+  );
+  return results;
+};
+
 export const hasAccessToRequete = async ({ requeteId, entiteId }: RequeteEntiteKey) => {
   const requete = await prisma.requeteEntite.findUnique({
     where: { requeteId_entiteId: { requeteId, entiteId } },

--- a/apps/frontend/src/components/common/filters/StatutFilter.test.tsx
+++ b/apps/frontend/src/components/common/filters/StatutFilter.test.tsx
@@ -12,11 +12,63 @@ describe('StatutFilter', () => {
   it('lets the user pick a statut via the dropdown checkbox filter', async () => {
     const onChange = vi.fn();
 
-    render(<StatutFilter selectedIds={[]} onChange={onChange} />);
+    render(<StatutFilter selectedIds={[]} counts={null} onChange={onChange} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'Statut' }));
     await userEvent.click(screen.getByRole('checkbox', { name: 'Nouveau' }));
 
     expect(onChange).toHaveBeenCalledWith(['NOUVEAU']);
+  });
+
+  it('appends the request count to each statut label when counts are provided', async () => {
+    render(
+      <StatutFilter
+        selectedIds={[]}
+        counts={{ NOUVEAU: 3, EN_COURS: 5, CLOTUREE: 0, TRAITEE: 2 }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Statut' }));
+
+    expect(screen.getByRole('checkbox', { name: 'Nouveau (3)' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'En cours (5)' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Clôturée (0)' })).toBeInTheDocument();
+  });
+
+  it('hides the "Pris en compte" statut when no request has it', async () => {
+    render(
+      <StatutFilter
+        selectedIds={[]}
+        counts={{ NOUVEAU: 3, EN_COURS: 5, CLOTUREE: 1, TRAITEE: 0 }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Statut' }));
+
+    expect(screen.queryByRole('checkbox', { name: /Pris en compte/ })).not.toBeInTheDocument();
+  });
+
+  it('shows the "Pris en compte" statut when at least one request has it', async () => {
+    render(
+      <StatutFilter
+        selectedIds={[]}
+        counts={{ NOUVEAU: 3, EN_COURS: 5, CLOTUREE: 1, TRAITEE: 2 }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Statut' }));
+
+    expect(screen.getByRole('checkbox', { name: 'Pris en compte (2)' })).toBeInTheDocument();
+  });
+
+  it('shows the "Pris en compte" statut when it is already selected even without counts', async () => {
+    render(<StatutFilter selectedIds={['TRAITEE']} counts={null} onChange={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Statut/ }));
+
+    expect(screen.getByRole('checkbox', { name: 'Pris en compte' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/common/filters/StatutFilter.tsx
+++ b/apps/frontend/src/components/common/filters/StatutFilter.tsx
@@ -1,28 +1,41 @@
 import { REQUETE_STATUT_TYPES, requeteStatutType } from '@sirena/common/constants';
+import { useMemo } from 'react';
 import { DropdownCheckboxFilter } from './DropdownCheckboxFilter';
+
+type CountsMap = Record<string, number>;
 
 type Props = {
   selectedIds: string[];
+  counts: CountsMap | null;
   onChange: (ids: string[]) => void;
   onOpen?: () => void;
   onClose?: () => void;
 };
 
-const STATUT_OPTIONS = [
-  REQUETE_STATUT_TYPES.NOUVEAU,
-  REQUETE_STATUT_TYPES.EN_COURS,
-  REQUETE_STATUT_TYPES.CLOTUREE,
-  REQUETE_STATUT_TYPES.TRAITEE,
-].map((id) => ({ value: id, label: requeteStatutType[id] }));
+const BASE_STATUTS = [REQUETE_STATUT_TYPES.NOUVEAU, REQUETE_STATUT_TYPES.EN_COURS, REQUETE_STATUT_TYPES.CLOTUREE];
 
-export function StatutFilter({ selectedIds, onChange, onOpen, onClose }: Props) {
+export function StatutFilter({ selectedIds, counts, onChange, onOpen, onClose }: Props) {
+  const options = useMemo(() => {
+    const traiteeCount = counts?.[REQUETE_STATUT_TYPES.TRAITEE];
+    const showTraitee = (traiteeCount ?? 0) > 0 || selectedIds.includes(REQUETE_STATUT_TYPES.TRAITEE);
+    const statuts = showTraitee ? [...BASE_STATUTS, REQUETE_STATUT_TYPES.TRAITEE] : BASE_STATUTS;
+
+    return statuts.map((id) => {
+      const count = counts?.[id];
+      return {
+        value: id,
+        label: `${requeteStatutType[id]}${count !== undefined ? ` (${count})` : ''}`,
+      };
+    });
+  }, [counts, selectedIds]);
+
   return (
     <DropdownCheckboxFilter
       buttonLabel="Statut"
       selectedValuesLabel={(count) => `statut${count > 1 ? 's' : ''} sélectionné${count > 1 ? 's' : ''}`}
       legend="Filtrer les requêtes par statut"
-      hintText="Statut de la requête"
-      options={STATUT_OPTIONS}
+      hintText="Statut de la requête (nombre de requêtes)"
+      options={options}
       selectedValues={selectedIds}
       onChange={onChange}
       onOpen={onOpen}

--- a/apps/frontend/src/components/common/filters/StatutFilter.tsx
+++ b/apps/frontend/src/components/common/filters/StatutFilter.tsx
@@ -16,9 +16,9 @@ const BASE_STATUTS = [REQUETE_STATUT_TYPES.NOUVEAU, REQUETE_STATUT_TYPES.EN_COUR
 
 export function StatutFilter({ selectedIds, counts, onChange, onOpen, onClose }: Props) {
   const options = useMemo(() => {
-    const traiteeCount = counts?.[REQUETE_STATUT_TYPES.TRAITEE];
-    const showTraitee = (traiteeCount ?? 0) > 0 || selectedIds.includes(REQUETE_STATUT_TYPES.TRAITEE);
-    const statuts = showTraitee ? [...BASE_STATUTS, REQUETE_STATUT_TYPES.TRAITEE] : BASE_STATUTS;
+    const requetesTraiteeCount = counts?.[REQUETE_STATUT_TYPES.TRAITEE];
+    const showRequeteTraitee = (requetesTraiteeCount ?? 0) > 0 || selectedIds.includes(REQUETE_STATUT_TYPES.TRAITEE);
+    const statuts = showRequeteTraitee ? [...BASE_STATUTS, REQUETE_STATUT_TYPES.TRAITEE] : BASE_STATUTS;
 
     return statuts.map((id) => {
       const count = counts?.[id];

--- a/apps/frontend/src/components/common/tables/requetesEntites.filters.tsx
+++ b/apps/frontend/src/components/common/tables/requetesEntites.filters.tsx
@@ -1,4 +1,9 @@
-import { DOMAINES_FONCTIONNELS, entiteTypes, REQUETE_PRIORITE_TYPES } from '@sirena/common/constants';
+import {
+  DOMAINES_FONCTIONNELS,
+  entiteTypes,
+  REQUETE_PRIORITE_TYPES,
+  REQUETE_STATUT_TYPES,
+} from '@sirena/common/constants';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useCallback, useMemo, useState } from 'react';
 import { CheckboxFilter } from '@/components/common/filters/CheckboxFilter';
@@ -8,6 +13,7 @@ import { StatutFilter } from '@/components/common/filters/StatutFilter';
 import { useDepartementCounts } from '@/hooks/queries/departementCounts.hook';
 import { useDomaineCounts } from '@/hooks/queries/domaineCounts.hook';
 import { useProfile } from '@/hooks/queries/profile.hook';
+import { useStatutCounts } from '@/hooks/queries/statutCounts.hook';
 import { splitCsv } from '@/utils/filters';
 import { getRequetesQuickFiltersViewModel } from './requetesEntites.filters.model';
 
@@ -22,8 +28,11 @@ export function RequetesEntiteQuickFilters() {
   const arsDepartements = useMemo(() => profile?.topEntiteDepartements ?? [], [profile?.topEntiteDepartements]);
   const [isDepartementDropdownOpen, setIsDepartementDropdownOpen] = useState(false);
   const [isDomaineDropdownOpen, setIsDomaineDropdownOpen] = useState(false);
+  const [isStatutDropdownOpen, setIsStatutDropdownOpen] = useState(false);
 
   const allDomaineIds = useMemo(() => Object.values(DOMAINES_FONCTIONNELS).join(','), []);
+
+  const allStatutIds = useMemo(() => Object.values(REQUETE_STATUT_TYPES).join(','), []);
 
   const selectedDepartements = useMemo(() => splitCsv(queries.departementCodes), [queries.departementCodes]);
 
@@ -54,6 +63,18 @@ export function RequetesEntiteQuickFilters() {
     if (!domaineCountsData) return null;
     return Object.fromEntries(domaineCountsData.map((d) => [d.id, d.count]));
   }, [domaineCountsData]);
+
+  const { data: statutCountsData } = useStatutCounts({
+    statutIds: allStatutIds,
+    entiteId: queries.entiteId,
+    search: queries.search,
+    enabled: isStatutDropdownOpen,
+  });
+
+  const statutCounts = useMemo(() => {
+    if (!statutCountsData) return null;
+    return Object.fromEntries(statutCountsData.map((s) => [s.id, s.count]));
+  }, [statutCountsData]);
 
   const handleAffectationChange = useCallback(
     (checked: boolean) => {
@@ -157,7 +178,13 @@ export function RequetesEntiteQuickFilters() {
           onClose={() => setIsDomaineDropdownOpen(false)}
         />
 
-        <StatutFilter selectedIds={selectedStatuts} onChange={handleStatutChange} />
+        <StatutFilter
+          selectedIds={selectedStatuts}
+          counts={statutCounts}
+          onChange={handleStatutChange}
+          onOpen={() => setIsStatutDropdownOpen(true)}
+          onClose={() => setIsStatutDropdownOpen(false)}
+        />
       </div>
     </fieldset>
   );

--- a/apps/frontend/src/hooks/queries/statutCounts.hook.ts
+++ b/apps/frontend/src/hooks/queries/statutCounts.hook.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchStatutCounts } from '@/lib/api/fetchStatutCounts';
+
+type StatutCountsParams = {
+  statutIds: string;
+  entiteId?: string;
+  search?: string;
+  enabled?: boolean;
+};
+
+export const useStatutCounts = ({ enabled = true, ...params }: StatutCountsParams) =>
+  useQuery({
+    queryKey: ['statutCounts', params],
+    queryFn: () => fetchStatutCounts(params),
+    enabled: enabled && !!params.statutIds,
+  });

--- a/apps/frontend/src/lib/api/fetchStatutCounts.ts
+++ b/apps/frontend/src/lib/api/fetchStatutCounts.ts
@@ -1,0 +1,17 @@
+import { client } from '@/lib/api/hc.ts';
+import { handleRequestErrors } from '@/lib/api/tanstackQuery.ts';
+
+export type StatutCount = { id: string; count: number };
+
+export async function fetchStatutCounts(params: { statutIds: string; entiteId?: string; search?: string }) {
+  const res = await client['requetes-entite']['statut-counts'].$get({
+    query: {
+      statutIds: params.statutIds,
+      ...(params.entiteId && { entiteId: params.entiteId }),
+      ...(params.search && { search: params.search }),
+    },
+  });
+  await handleRequestErrors(res);
+  const { data } = await res.json();
+  return data as StatutCount[];
+}


### PR DESCRIPTION
Réouverture de #1400 (mergée dans `main`) vers `validation`.

Contenu identique : ajout d'un endpoint pour récupérer le nombre de requêtes par statut.

Commits repris :
- feat: add endpoint to fetch requetes counts by statut
- fix: rename some vars