### PR TITLE
fix: guard statistiques rendering against malformed Metabase payload

### DIFF
--- a/apps/frontend/src/components/statistics/chartData.ts
+++ b/apps/frontend/src/components/statistics/chartData.ts
@@ -47,7 +47,10 @@ const PERCENT_SEMANTIC_TYPE = 'type/Percentage';
 const isPercentByName = (col: MetabaseColumn): boolean =>
   /%|pourcent/i.test(col.display_name) || /%|pourcent/i.test(col.name);
 
-export const parseCard = ({ cols, rows }: CardData): ParsedCard | null => {
+export const parseCard = (data: CardData | undefined | null): ParsedCard | null => {
+  if (!data) return null;
+  const { cols, rows } = data;
+  if (!Array.isArray(cols) || !Array.isArray(rows)) return null;
   if (cols.length < 2 || rows.length === 0) return null;
 
   const percentColumn =

--- a/apps/frontend/src/routes/_auth/_user/statistiques.tsx
+++ b/apps/frontend/src/routes/_auth/_user/statistiques.tsx
@@ -53,9 +53,11 @@ function formatValue(value: unknown): string {
 }
 
 function getScalarValue(card: StatisticsCard): unknown | undefined {
-  const { cols, rows } = card.data;
+  const { cols, rows } = card.data ?? {};
+  if (!Array.isArray(cols) || !Array.isArray(rows)) return undefined;
   if (cols.length !== 1 || rows.length !== 1) return undefined;
   const [row] = rows;
+  if (!Array.isArray(row)) return undefined;
   const [value] = row;
   return value;
 }
@@ -177,15 +179,16 @@ export function RouteComponent() {
       </p>
       <QueryStateHandler query={query} noDataComponent={<p>Aucune carte configurée dans le dashboard Metabase.</p>}>
         {({ data }) => {
-          if (data.cards.length === 0) {
+          const cards = Array.isArray(data.cards) ? data.cards : [];
+          if (cards.length === 0) {
             return <p>Aucune carte configurée dans le dashboard Metabase.</p>;
           }
 
-          const cards = [...data.cards].sort(byGridPosition);
+          const sortedCards = [...cards].sort(byGridPosition);
 
           return (
             <div className={styles['mb-grid']}>
-              {cards.map((card) => (
+              {sortedCards.map((card) => (
                 <section key={`${card.dashcardId}-${card.id}`} className={styles['mb-cell']} style={cellStyle(card)}>
                   <CardContent card={card} />
                 </section>


### PR DESCRIPTION
The /statistiques page assumed the dashboard payload always contained well-formed arrays. A card with missing data.cols/data.rows, or an absent cards list, crashed the whole page render:

- getScalarValue read cols.length / rows.length and destructured rows without checking they are arrays (TypeError: reading 'length').
- The route spread [...data.cards] and read data.cards.length unguarded (TypeError: not iterable / reading 'length').
- parseCard destructured cols/rows from a possibly-undefined data.

Add Array.isArray guards so a malformed card degrades gracefully instead of throwing.

Fixes PSN-SIRENA-FRONTEND-M2-2V
Fixes PSN-SIRENA-FRONTEND-M2-2S