### PR TITLE
[SIRENA-679] afficher la date de fin des faits quand seule celle-ci est renseignée 

### DIFF
--- a/apps/frontend/src/components/requestId/sections/SituationSection.tsx
+++ b/apps/frontend/src/components/requestId/sections/SituationSection.tsx
@@ -488,11 +488,13 @@ export const SituationSection = ({ id, requestId, situation, receptionType, edit
           <>
             <SectionTitle level={4}>Période des faits</SectionTitle>
             <p className={fr.cx('fr-mb-3w')}>
-              {fait.dateDebut && !fait.dateFin
-                ? `Depuis le ${new Date(fait.dateDebut).toLocaleDateString('fr-FR')}`
-                : fait.dateDebut && fait.dateFin
-                  ? `Du ${new Date(fait.dateDebut).toLocaleDateString('fr-FR')} au ${new Date(fait.dateFin).toLocaleDateString('fr-FR')}`
-                  : null}
+              {fait.dateDebut && fait.dateFin
+                ? `Du ${new Date(fait.dateDebut).toLocaleDateString('fr-FR')} au ${new Date(fait.dateFin).toLocaleDateString('fr-FR')}`
+                : fait.dateDebut
+                  ? `Depuis le ${new Date(fait.dateDebut).toLocaleDateString('fr-FR')}`
+                  : fait.dateFin
+                    ? `Jusqu'au ${new Date(fait.dateFin).toLocaleDateString('fr-FR')}`
+                    : null}
             </p>
           </>
         )}


### PR DESCRIPTION
Problème

Dans le détail de la requête (SituationSection.tsx, section « Période des faits »), le bloc était affiché dès que dateDebut ou dateFin était présente, mais le ternaire interne ne couvrait que deux cas :

- dateDebut seule → Depuis le …
- dateDebut et dateFin → Du … au …

Le cas « dateFin seule » tombait sur null : le titre « Période des faits » s'affichait alors sans aucune date.
