### PR TITLE
fix(e2e): cibler une requête non clôturée et réparer le sharding Playwright

### DIFF
--- a/.github/workflows/auto-deploy.yaml
+++ b/.github/workflows/auto-deploy.yaml
@@ -166,7 +166,7 @@ jobs:
           FRONTEND_URL: ${{ env.BASE_URL }}
 
       - name: Run Playwright tests
-        run: pnpm run test:e2e -- --shard=${{ matrix.shard }}/${{ matrix.total }}
+        run: pnpm exec playwright test --shard=${{ matrix.shard }}/${{ matrix.total }}
         working-directory: apps/frontend
         env:
           FRONTEND_URI: ${{ env.BASE_URL }}

--- a/apps/frontend/tests/requetesDetails.spec.ts
+++ b/apps/frontend/tests/requetesDetails.spec.ts
@@ -25,7 +25,8 @@ test.describe('Request Details Feature', () => {
     context = await browser.newContext({ storageState: authFile });
     page = await context.newPage();
 
-    await page.goto(`${baseUrl}/home`);
+    // Exclure les requêtes clôturées : elles sont en lecture seule (bouton « Ajouter une étape » masqué).
+    await page.goto(`${baseUrl}/home?statutIds=NOUVEAU,EN_COURS,TRAITEE`);
     await expect(page.getByText(/Bienvenue/)).toBeVisible();
 
     const requetesTable = page.getByRole('table');


### PR DESCRIPTION
Le test « ajout d'une étape » prenait la première requête de /home à l'aveugle ; celle-ci est désormais clôturée (lecture seule), donc le bouton « Ajouter une étape » n'existe plus et le test échouait de façon déterministe sur les 3 shards. On filtre la liste sur les statuts éditables (NOUVEAU, EN_COURS, TRAITEE) via le query param statutIds.

Par ailleurs `pnpm run test:e2e -- --shard=x/y` transmettait le `--` à Playwright, qui interprétait `--shard` comme un filtre de fichier : chaque shard rejouait les 13 tests (triple charge de login ProConnect, source de flaky). On invoque Playwright directement via `pnpm exec`.