### PR TITLE
fix: corrections des retours sur la refonte des étapes de traitement

### DIFF
--- a/apps/backend/src/features/declarants/declarants.notification.service.test.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.test.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: <test purposes> */
-import { RECEPTION_TYPE } from '@sirena/common/constants';
+import { RECEPTION_TYPE, REQUETE_ETAPE_STATUT_TYPES } from '@sirena/common/constants';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ACKNOWLEDGMENT_EMAIL_SUBJECT } from '../../config/tipimail.constant.js';
 import { sendTipimailEmail } from '../../libs/mail/tipimail.js';
@@ -20,6 +20,7 @@ vi.mock('../../libs/prisma.js', () => ({
     },
     requeteEtape: {
       updateMany: vi.fn(),
+      update: vi.fn(),
       findFirst: vi.fn(),
     },
     requeteEtapeNote: {
@@ -474,5 +475,37 @@ describe('sendManualAcknowledgmentEmail() — PDF attachment', () => {
     );
 
     expect(mockedRequeteEtapeNote.create).not.toHaveBeenCalled();
+  });
+
+  it('stamps dateRealisation when claiming the step as FAIT', async () => {
+    await sendManualAcknowledgmentEmail({
+      etapeId: 'etapeAck',
+      requeteId: 'req1',
+      entiteId: 'ent1',
+      userId: 'user123',
+    });
+
+    expect(mockedRequeteEtape.updateMany).toHaveBeenCalledWith({
+      where: { id: 'etapeAck', statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE },
+      data: { statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT, dateRealisation: expect.any(Date) },
+    });
+  });
+
+  it('clears dateRealisation when rolling back after a send failure', async () => {
+    mockedSendTipimailEmail.mockRejectedValueOnce(new Error('smtp down'));
+
+    await expect(
+      sendManualAcknowledgmentEmail({
+        etapeId: 'etapeAck',
+        requeteId: 'req1',
+        entiteId: 'ent1',
+        userId: 'user123',
+      }),
+    ).rejects.toThrow('smtp down');
+
+    expect(mockedRequeteEtape.update).toHaveBeenCalledWith({
+      where: { id: 'etapeAck' },
+      data: { statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE, dateRealisation: null },
+    });
   });
 });

--- a/apps/backend/src/features/declarants/declarants.notification.service.ts
+++ b/apps/backend/src/features/declarants/declarants.notification.service.ts
@@ -287,9 +287,10 @@ export async function sendManualAcknowledgmentEmail({
 }): Promise<void> {
   const logger = getLoggerStore();
 
+  const markedDoneAt = new Date();
   const claimResult = await prisma.requeteEtape.updateMany({
     where: { id: etapeId, statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE },
-    data: { statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT },
+    data: { statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT, dateRealisation: markedDoneAt },
   });
 
   if (claimResult.count === 0) {
@@ -348,8 +349,8 @@ export async function sendManualAcknowledgmentEmail({
         entity: 'RequeteEtape',
         entityId: etapeId,
         action: ChangeLogAction.UPDATED,
-        before: { statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE },
-        after: { statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT },
+        before: { statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE, dateRealisation: null },
+        after: { statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT, dateRealisation: markedDoneAt.toISOString() },
         changedById: userId,
       });
     } catch (changelogError) {
@@ -409,7 +410,7 @@ export async function sendManualAcknowledgmentEmail({
     try {
       await prisma.requeteEtape.update({
         where: { id: etapeId },
-        data: { statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE },
+        data: { statutId: REQUETE_ETAPE_STATUT_TYPES.A_FAIRE, dateRealisation: null },
       });
     } catch (rollbackError) {
       logger.error(
@@ -553,7 +554,7 @@ export async function sendDeclarantAcknowledgmentEmail(requeteId: string): Promi
     // Update acknowledgment step automatically for top entities only
     const entiteIdsToUpdate = topEntites.map((e) => e.id);
     try {
-      await updateAcknowledgmentStep(requeteId, entiteIdsToUpdate);
+      await updateAcknowledgmentStep(requeteId, entiteIdsToUpdate, sentDate);
     } catch (stepUpdateError) {
       logger.error(
         { requeteId, error: stepUpdateError },

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -536,27 +536,6 @@ describe('RequeteEtapes.service.ts', () => {
       });
     });
 
-    it('filters out empty notes (legacy notes that only held files)', async () => {
-      const makeNote = (id: string, texte: string): RequeteEtapeNote => ({
-        id,
-        texte,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        authorId: 'authorId',
-        requeteEtapeId: 'requeteEtapeId',
-      });
-      const etapeWithMixedNotes: typeof requeteEtapeWithNotesAndFiles = {
-        ...requeteEtapeWithNotesAndFiles,
-        notes: [makeNote('has-text', 'Real note'), makeNote('empty', ''), makeNote('whitespace', '   ')],
-      };
-      vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([etapeWithMixedNotes]);
-      vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(1);
-
-      const result = await getRequeteEtapes('requeteId', 'entiteId', { offset: 0, limit: 10 });
-
-      expect(result.data[0].notes).toEqual([expect.objectContaining({ id: 'has-text', texte: 'Real note' })]);
-    });
-
     it('should retrieve RequeteEtapes for a given RequeteEntite with no limit', async () => {
       vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([requeteEtapeWithNotesAndFiles]);
       vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(1);

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -536,6 +536,28 @@ describe('RequeteEtapes.service.ts', () => {
       });
     });
 
+    it('filters out empty notes (legacy notes that only held files)', async () => {
+      const makeNote = (id: string, texte: string): RequeteEtapeNote => ({
+        id,
+        texte,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        authorId: 'authorId',
+        requeteEtapeId: 'requeteEtapeId',
+      });
+      vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([
+        {
+          ...requeteEtapeWithNotesAndFiles,
+          notes: [makeNote('has-text', 'Real note'), makeNote('empty', ''), makeNote('whitespace', '   ')],
+        },
+      ]);
+      vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(1);
+
+      const result = await getRequeteEtapes('requeteId', 'entiteId', { offset: 0, limit: 10 });
+
+      expect(result.data[0].notes).toEqual([expect.objectContaining({ id: 'has-text', texte: 'Real note' })]);
+    });
+
     it('should retrieve RequeteEtapes for a given RequeteEntite with no limit', async () => {
       vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([requeteEtapeWithNotesAndFiles]);
       vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(1);

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -871,51 +871,33 @@ describe('RequeteEtapes.service.ts', () => {
 
   describe('getEtapePermissions', () => {
     it('MANUAL step is fully editable', () => {
-      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'A_FAIRE', requete: { createdById: 'agent-1' } })).toEqual(
-        {
-          editable: true,
-          canOnlyEditNotes: false,
-        },
-      );
+      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'A_FAIRE' })).toEqual({
+        editable: true,
+        canOnlyEditNotes: false,
+      });
     });
 
     it('CLOTUREE step is not editable', () => {
-      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'CLOTUREE', requete: { createdById: 'a' } })).toEqual({
+      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'CLOTUREE' })).toEqual({
         editable: false,
         canOnlyEditNotes: false,
       });
     });
 
     it('CREATION and REOPEN steps are not editable', () => {
-      expect(getEtapePermissions({ type: 'CREATION', statutId: 'FAIT', requete: { createdById: null } }).editable).toBe(
-        false,
-      );
-      expect(getEtapePermissions({ type: 'REOPEN', statutId: 'FAIT', requete: { createdById: 'a' } }).editable).toBe(
-        false,
-      );
+      expect(getEtapePermissions({ type: 'CREATION', statutId: 'FAIT' }).editable).toBe(false);
+      expect(getEtapePermissions({ type: 'REOPEN', statutId: 'FAIT' }).editable).toBe(false);
     });
 
-    it('automatic ACR (requete without createdById) is notes-only', () => {
-      expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: null } })).toEqual(
-        {
+    it('ACKNOWLEDGMENT step is always notes-only (automatic and manual behave identically)', () => {
+      // Regardless of statut or who created the request, an ACR is a notes/attachments container:
+      // status, name and date stay locked.
+      for (const statutId of ['FAIT', 'A_FAIRE']) {
+        expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId })).toEqual({
           editable: true,
           canOnlyEditNotes: true,
-        },
-      );
-      // even before being marked FAIT, an automatic ACR stays notes-only
-      expect(
-        getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'A_FAIRE', requete: { createdById: null } }),
-      ).toEqual({ editable: true, canOnlyEditNotes: true });
-    });
-
-    it('manual ACR (requete with createdById) is fully editable', () => {
-      // a manually-sent ACR is not locked: an agent can still edit status/date/files
-      expect(
-        getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', requete: { createdById: 'agent-1' } }),
-      ).toEqual({ editable: true, canOnlyEditNotes: false });
-      expect(
-        getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'A_FAIRE', requete: { createdById: 'agent-1' } }),
-      ).toEqual({ editable: true, canOnlyEditNotes: false });
+        });
+      }
     });
   });
 
@@ -1069,7 +1051,7 @@ describe('RequeteEtapes.service.ts', () => {
       expect(deleteFileFromMinio).toHaveBeenCalledWith('b.pdf');
     });
 
-    it('automatic ACR: applies notes only, leaves fields and files untouched', async () => {
+    it('ACR: locks step fields but still applies notes and file changes, preserving the AR PDF', async () => {
       vi.mocked(prisma.requeteEtape.findUnique)
         .mockResolvedValueOnce({
           id: 'ack',
@@ -1077,25 +1059,35 @@ describe('RequeteEtapes.service.ts', () => {
           statutId: 'FAIT',
           entiteId: 'e1',
           notes: [],
-          uploadedFiles: [{ id: 'ar', canDelete: false, filePath: 'ar.pdf' }],
+          uploadedFiles: [
+            { id: 'ar', canDelete: false, filePath: 'ar.pdf' },
+            { id: 'old', canDelete: true, filePath: 'old.pdf' },
+          ],
           requete: { createdById: null },
         } as never)
         .mockResolvedValueOnce({ ...requeteEtape, id: 'ack' });
 
       const tx = makeTx();
+      vi.mocked(isUserOwner).mockResolvedValue(true);
       vi.mocked(prisma.$transaction).mockImplementation((async (cb: (t: unknown) => unknown) => cb(tx)) as never);
+      vi.mocked(deleteFileFromMinio).mockResolvedValue();
 
       await updateProcessingEtape(
         'ack',
         'user-1',
-        { nom: 'Changed', statutId: 'A_FAIRE', notes: [{ texte: 'note added' }], fileIds: [] },
+        { nom: 'Changed', statutId: 'A_FAIRE', notes: [{ texte: 'note added' }], fileIds: ['ar', 'new'] },
         logger,
       );
 
+      // Step metadata stays locked (name/status/date untouched)...
       expect(tx.requeteEtape.update).not.toHaveBeenCalled();
+      // ...but notes and attachments are applied.
       expect(tx.requeteEtapeNote.create).toHaveBeenCalledTimes(1);
-      expect(tx.uploadedFile.deleteMany).not.toHaveBeenCalled();
-      expect(tx.uploadedFile.updateMany).not.toHaveBeenCalled();
+      expect(setEtapeFile).toHaveBeenCalledWith('ack', ['new'], 'e1', 'user-1', tx);
+      // The deletable file is removed; the AR PDF (canDelete === false) is preserved.
+      expect(tx.uploadedFile.deleteMany).toHaveBeenCalledWith({ where: { id: { in: ['old'] } } });
+      expect(deleteFileFromMinio).toHaveBeenCalledWith('old.pdf');
+      expect(deleteFileFromMinio).not.toHaveBeenCalledWith('ar.pdf');
     });
   });
 });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -545,12 +545,11 @@ describe('RequeteEtapes.service.ts', () => {
         authorId: 'authorId',
         requeteEtapeId: 'requeteEtapeId',
       });
-      vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([
-        {
-          ...requeteEtapeWithNotesAndFiles,
-          notes: [makeNote('has-text', 'Real note'), makeNote('empty', ''), makeNote('whitespace', '   ')],
-        },
-      ]);
+      const etapeWithMixedNotes: typeof requeteEtapeWithNotesAndFiles = {
+        ...requeteEtapeWithNotesAndFiles,
+        notes: [makeNote('has-text', 'Real note'), makeNote('empty', ''), makeNote('whitespace', '   ')],
+      };
+      vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([etapeWithMixedNotes]);
       vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(1);
 
       const result = await getRequeteEtapes('requeteId', 'entiteId', { offset: 0, limit: 10 });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -570,6 +570,9 @@ export const getRequeteEtapes = async (requeteId: string, entiteId: string | nul
       ...etape,
       editable,
       canOnlyEditNotes,
+      // Hide empty notes: some legacy notes only held files, which were moved to the step level
+      // (backfill_uploaded_file_requete_etape), leaving a note with no text and nothing to show.
+      notes: etape.notes.filter((note) => Boolean(note.texte?.trim())),
       uploadedFiles: etape.uploadedFiles.map(sanitizeFile),
     };
   });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -152,15 +152,15 @@ export const createDefaultRequeteEtapes = async (
 export const getEtapePermissions = (etape: {
   type: string;
   statutId: string | null;
-  requete: { createdById: string | null } | null;
 }): { editable: boolean; canOnlyEditNotes: boolean } => {
   if (etape.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) return { editable: false, canOnlyEditNotes: false };
   if (etape.type === REQUETE_ETAPE_TYPES.CREATION || etape.type === REQUETE_ETAPE_TYPES.REOPEN) {
     return { editable: false, canOnlyEditNotes: false };
   }
-  // Spec: only an ACR sent automatically is locked (status + uploaded files), notes always editable.
-  // Automatic = request not created by an agent (createdById null) ; a manual ACR stays fully editable.
-  const canOnlyEditNotes = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && etape.requete?.createdById == null;
+  // An acknowledgment step is always a notes/attachments container: status, name and date stay
+  // locked, only notes can be edited. Manual ACRs behave exactly like automatic ones (the AR send,
+  // auto or semi-manual from SIRENA, is authoritative), so this no longer depends on who created the request.
+  const canOnlyEditNotes = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
   return { editable: true, canOnlyEditNotes };
 };
 
@@ -384,7 +384,6 @@ export const updateProcessingEtape = async (
     include: {
       notes: { select: { id: true, authorId: true, texte: true } },
       uploadedFiles: { select: { id: true, canDelete: true, filePath: true } },
-      requete: { select: { createdById: true } },
     },
   });
   if (!etape) {
@@ -405,7 +404,8 @@ export const updateProcessingEtape = async (
   let noteChangelogs: NoteChangelogEntry[] = [];
 
   await prisma.$transaction(async (tx) => {
-    // canOnlyEditNotes (automatic ACR) only persists notes
+    // canOnlyEditNotes (ACR) locks the step itself (name/status/date) but notes and
+    // attachments stay editable — the AR PDF is kept via diffEtapeFiles (canDelete === false).
     if (!canOnlyEditNotes) {
       await tx.requeteEtape.update({
         where: { id: stepId },
@@ -415,16 +415,14 @@ export const updateProcessingEtape = async (
 
     noteChangelogs = await applyEtapeNoteChanges(tx, stepId, userId, data.notes, notesDiff);
 
-    if (!canOnlyEditNotes) {
-      if (fileIdsToAttach.length > 0) {
-        if (!(await isUserOwner(userId, fileIdsToAttach, tx))) {
-          throw new FilesNotOwnedError('FILES_NOT_OWNED');
-        }
-        await setEtapeFile(stepId, fileIdsToAttach, etape.entiteId, userId, tx);
+    if (fileIdsToAttach.length > 0) {
+      if (!(await isUserOwner(userId, fileIdsToAttach, tx))) {
+        throw new FilesNotOwnedError('FILES_NOT_OWNED');
       }
-      if (filesToRemove.length > 0) {
-        await tx.uploadedFile.deleteMany({ where: { id: { in: filesToRemove.map((f) => f.id) } } });
-      }
+      await setEtapeFile(stepId, fileIdsToAttach, etape.entiteId, userId, tx);
+    }
+    if (filesToRemove.length > 0) {
+      await tx.uploadedFile.deleteMany({ where: { id: { in: filesToRemove.map((f) => f.id) } } });
     }
   });
 
@@ -432,7 +430,7 @@ export const updateProcessingEtape = async (
     noteChangelogs.map((ev) => logNoteChangelog(ev.action, ev.id, ev.before, ev.after, userId, logger)),
   );
 
-  if (!canOnlyEditNotes && filesToRemove.length > 0) {
+  if (filesToRemove.length > 0) {
     await cleanupRemovedEtapeFiles(filesToRemove, userId, logger);
   }
 
@@ -567,7 +565,6 @@ export const getRequeteEtapes = async (requeteId: string, entiteId: string | nul
     const { editable, canOnlyEditNotes } = getEtapePermissions({
       type: etape.type,
       statutId: etape.statutId,
-      requete: etape.requete ? { createdById: etape.requete.createdById } : null,
     });
     return {
       ...etape,

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -570,9 +570,6 @@ export const getRequeteEtapes = async (requeteId: string, entiteId: string | nul
       ...etape,
       editable,
       canOnlyEditNotes,
-      // Hide empty notes: some legacy notes only held files, which were moved to the step level
-      // (backfill_uploaded_file_requete_etape), leaving a note with no text and nothing to show.
-      notes: etape.notes.filter((note) => Boolean(note.texte?.trim())),
       uploadedFiles: etape.uploadedFiles.map(sanitizeFile),
     };
   });

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -593,7 +593,11 @@ export const getRequeteEtapeById = async (id: string) =>
  * @param requeteId - The ID of the requete
  * @param entiteIds - Array of entity IDs that received the acknowledgment email
  */
-export const updateAcknowledgmentStep = async (requeteId: string, entiteIds: string[]): Promise<void> => {
+export const updateAcknowledgmentStep = async (
+  requeteId: string,
+  entiteIds: string[],
+  sentDate: Date = new Date(),
+): Promise<void> => {
   const logger = getLoggerStore();
 
   try {
@@ -618,6 +622,7 @@ export const updateAcknowledgmentStep = async (requeteId: string, entiteIds: str
           id: etape.id,
           nom: etape.nom,
           statutId: etape.statutId,
+          dateRealisation: etape.dateRealisation?.toISOString() ?? null,
           requeteId: etape.requeteId,
           entiteId: etape.entiteId,
           createdAt: etape.createdAt.toISOString(),
@@ -628,6 +633,7 @@ export const updateAcknowledgmentStep = async (requeteId: string, entiteIds: str
           where: { id: etape.id },
           data: {
             statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT,
+            dateRealisation: sentDate,
           },
         });
 
@@ -635,6 +641,7 @@ export const updateAcknowledgmentStep = async (requeteId: string, entiteIds: str
           id: updatedEtape.id,
           nom: updatedEtape.nom,
           statutId: updatedEtape.statutId,
+          dateRealisation: updatedEtape.dateRealisation?.toISOString() ?? null,
           requeteId: updatedEtape.requeteId,
           entiteId: updatedEtape.entiteId,
           createdAt: updatedEtape.createdAt.toISOString(),

--- a/apps/frontend/src/components/requestId/processing/Step.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.test.tsx
@@ -172,6 +172,25 @@ describe('Step', () => {
     expect(screen.getByText('Texte de la note')).toBeInTheDocument();
   });
 
+  it('hides empty notes (legacy notes that only held files)', () => {
+    const author = { prenom: 'jeanne', nom: 'Moulon' };
+    render(
+      <Step
+        {...makeStep({
+          notes: [
+            { id: 'has-text', texte: 'Contenu réel', createdAt: '2026-05-19T10:00:00.000Z', author },
+            { id: 'empty', texte: '', createdAt: '2026-05-18T10:00:00.000Z', author },
+            { id: 'whitespace', texte: '   ', createdAt: '2026-05-17T10:00:00.000Z', author },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Contenu réel')).toBeInTheDocument();
+    // The two empty notes are not rendered — only one note block remains.
+    expect(screen.getAllByText(/Note rédigée le/)).toHaveLength(1);
+  });
+
   it('renders each step-level file as its own "Fichier ajouté le … par …" event', () => {
     render(
       <Step

--- a/apps/frontend/src/components/requestId/processing/Step.tsx
+++ b/apps/frontend/src/components/requestId/processing/Step.tsx
@@ -188,6 +188,9 @@ const StepComponent = ({
   const showAFaireBadge = statutId === REQUETE_ETAPE_STATUT_TYPES.A_FAIRE;
   const canEditStep = canEdit && step.editable;
 
+  // Legacy notes that only held files show up empty once the files were moved to the step level; hide them.
+  const visibleNotes = notes.filter((note) => note.texte?.trim());
+
   const clotureReasonLabels =
     statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE
       ? step.clotureReason.map((reason) => reason.label).filter(Boolean)
@@ -322,12 +325,12 @@ const StepComponent = ({
         ) : (
           <>
             <div className={styles['request-notes']}>
-              {notes.slice(0, isOpen ? notes.length : 3).map((note: StepType['notes'][number]) => (
+              {visibleNotes.slice(0, isOpen ? visibleNotes.length : 3).map((note: StepType['notes'][number]) => (
                 <StepNote key={note.id} content={note.texte} author={note.author} createdAt={note.createdAt} />
               ))}
             </div>
             <div className={styles['request-notes-distplay']}>
-              {notes.length > 3 && (
+              {visibleNotes.length > 3 && (
                 <button type="button" className="fr-btn-link" onClick={() => setIsOpen(!isOpen)}>
                   {isOpen ? 'Masquer' : 'Afficher'} les notes précédentes{' '}
                   <span

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
@@ -237,7 +237,7 @@ describe('StepFormPanel', () => {
     expect(deleteMutateAsync).toHaveBeenCalledWith({ id: 'step-1' });
   });
 
-  it('locks status/name/files for an automatic ACR step (canOnlyEditNotes)', () => {
+  it('locks status/name but allows notes and attachments for an ACR step (canOnlyEditNotes)', () => {
     const ref = createRef<StepFormPanelRef>();
     render(<StepFormPanel ref={ref} requestId="REQ-1" />);
 
@@ -252,10 +252,12 @@ describe('StepFormPanel', () => {
       ),
     );
 
+    // Step metadata stays locked...
     expect(screen.getByLabelText("Nom de l'étape (obligatoire)")).toBeDisabled();
     expect(screen.getByLabelText('Fait')).toBeDisabled();
     expect(screen.getByLabelText('À faire')).toBeDisabled();
-    expect(screen.queryByText('Sélectionner un fichier')).not.toBeInTheDocument();
+    // ...but notes and attachments can still be added.
+    expect(screen.getByText('Sélectionner un fichier')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ajouter une note' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -172,13 +172,15 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
           : '',
     );
 
+    // Skip empty notes (legacy notes that only held files, since moved to the step level).
+    const nonEmptyNotes = step.notes.filter((note) => note.texte?.trim());
     setNotes(
-      step.notes
+      nonEmptyNotes
         .filter((note) => note.author !== null)
         .map((note) => ({ key: nextNoteKey(), id: note.id, texte: note.texte, createdAt: note.createdAt })),
     );
     setReadOnlyNotes(
-      step.notes
+      nonEmptyNotes
         .filter((note) => note.author === null)
         .map((note) => ({ id: note.id, texte: note.texte, createdAt: note.createdAt })),
     );

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -391,8 +391,8 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
 
                   {fieldsLocked && (
                     <p className={`fr-text--sm ${styles.lockHint}`}>
-                      Cette étape correspond à un accusé de réception automatique : seules les notes peuvent être
-                      ajoutées ou modifiées.
+                      Cette étape correspond à un accusé de réception : le statut, le nom et la date ne sont pas
+                      modifiables ; vous pouvez uniquement ajouter des notes et des pièces jointes.
                     </p>
                   )}
 
@@ -556,7 +556,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                                 scanStatus={file.scanStatus}
                                 sanitizeStatus={file.sanitizeStatus}
                               />
-                              {!fieldsLocked && file.canDelete && (
+                              {file.canDelete && (
                                 <Button
                                   type="button"
                                   priority="tertiary"
@@ -574,30 +574,28 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                       </section>
                     )}
 
-                    {!fieldsLocked && (
-                      <section className={styles.attachmentSection}>
-                        <p className={`fr-label ${styles.attachmentTitle}`}>
-                          {existingFiles.length > 0 ? "Ajouter d'autres pièces jointes" : 'Ajouter des pièces jointes'}
-                        </p>
-                        <FileDropZone
-                          selectedFiles={filesToUpload}
-                          fileErrors={fileErrors}
-                          isUploading={isLoading}
-                          onFilesSelect={handleSelectFiles}
-                          title="Sélectionner ou glisser un fichier à joindre"
-                          buttonLabel="Sélectionner un fichier"
-                          className={styles.drawerDropZone}
-                          errorTextClassName={styles.errorText}
-                        />
-                        <SelectedFilesList
-                          files={filesToUpload}
-                          title="Fichiers sélectionnés"
-                          className={styles.selectedFilesList}
-                          variant="compact"
-                          onRemove={(fileName) => setFilesToUpload((prev) => prev.filter((f) => f.name !== fileName))}
-                        />
-                      </section>
-                    )}
+                    <section className={styles.attachmentSection}>
+                      <p className={`fr-label ${styles.attachmentTitle}`}>
+                        {existingFiles.length > 0 ? "Ajouter d'autres pièces jointes" : 'Ajouter des pièces jointes'}
+                      </p>
+                      <FileDropZone
+                        selectedFiles={filesToUpload}
+                        fileErrors={fileErrors}
+                        isUploading={isLoading}
+                        onFilesSelect={handleSelectFiles}
+                        title="Sélectionner ou glisser un fichier à joindre"
+                        buttonLabel="Sélectionner un fichier"
+                        className={styles.drawerDropZone}
+                        errorTextClassName={styles.errorText}
+                      />
+                      <SelectedFilesList
+                        files={filesToUpload}
+                        title="Fichiers sélectionnés"
+                        className={styles.selectedFilesList}
+                        variant="compact"
+                        onRemove={(fileName) => setFilesToUpload((prev) => prev.filter((f) => f.name !== fileName))}
+                      />
+                    </section>
 
                     <div className={styles.footerActions}>
                       {mode === 'edit' && !fieldsLocked && (

--- a/apps/frontend/src/components/statistics/ExportRequetesButton.test.tsx
+++ b/apps/frontend/src/components/statistics/ExportRequetesButton.test.tsx
@@ -70,7 +70,11 @@ describe('ExportRequetesButton', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Exporter les requêtes' }));
 
-    expect(browserDownload.createObjectURLSpy).toHaveBeenCalledWith(expect.any(Blob));
+    // Assert on the blob content rather than `expect.any(Blob)`: `response.blob()` returns a
+    // Node/undici Blob that is not an instance of the test-scope global Blob, so a class check flakes.
+    expect(browserDownload.createObjectURLSpy).toHaveBeenCalledOnce();
+    const [blobArg] = browserDownload.createObjectURLSpy.mock.calls[0] as [Blob];
+    await expect(blobArg.text()).resolves.toBe(csv);
     expect(browserDownload.clickSpy).toHaveBeenCalledOnce();
     expect(browserDownload.clickedLink).toMatchObject({
       download: 'export-requetes-sirena-2026-06-18.csv',

--- a/packages/db/prisma/migrations/20260716120000_backfill_date_realisation_acknowledgment/migration.sql
+++ b/packages/db/prisma/migrations/20260716120000_backfill_date_realisation_acknowledgment/migration.sql
@@ -1,0 +1,44 @@
+-- Backfill dateRealisation for ACKNOWLEDGMENT steps.
+-- The earlier backfill (20260616130000) only handled type = 'MANUAL', so every
+-- "Envoi de l'accusé de réception" step (type = 'ACKNOWLEDGMENT') that was marked
+-- FAIT before this release kept dateRealisation = NULL. The edit panel then fell
+-- back to today's date instead of the real send/mark-done date.
+-- We rebuild the missing date from, in priority order:
+--   1. the ChangeLog transition A_FAIRE -> FAIT (exact date it was set to "Fait"),
+--   2. the AR PDF creation date (the non-deletable file attached on send),
+--   3. the step's updatedAt (safety net; ~= send date for these rows).
+UPDATE "RequeteEtape" re
+SET "dateRealisation" = sub."date"
+FROM (
+  SELECT
+    e.id AS etape_id,
+    -- First non-null source (see priority above)
+    COALESCE(cl."changedAt", uf."createdAt", e."updatedAt") AS "date"
+  FROM "RequeteEtape" e
+  -- Source 1: latest logged transition to FAIT for this step.
+  LEFT JOIN LATERAL (
+    SELECT cl."changedAt"
+    FROM "ChangeLog" cl
+    WHERE cl.entity = 'RequeteEtape'
+      AND cl."entityId" = e.id
+      AND cl.action = 'UPDATED'
+      AND cl.after->>'statutId' = 'FAIT'        
+      AND (cl.before->>'statutId') IS DISTINCT FROM 'FAIT'
+    ORDER BY cl."changedAt" DESC
+    LIMIT 1
+  ) cl ON true
+  -- Source 2: the AR PDF is attached with canDelete = false; its createdAt ~= send time.
+  LEFT JOIN LATERAL (
+    SELECT uf."createdAt"
+    FROM "UploadedFile" uf
+    WHERE uf."requeteEtapeId" = e.id
+      AND uf."canDelete" = false
+    ORDER BY uf."createdAt" ASC
+    LIMIT 1
+  ) uf ON true
+  -- Only the acknowledgment steps that are done but still missing the date.
+  WHERE e."type" = 'ACKNOWLEDGMENT'
+    AND e."statutId" = 'FAIT'
+    AND e."dateRealisation" IS NULL
+) sub
+WHERE re.id = sub.etape_id;


### PR DESCRIPTION
Corrige trois retours sur la refonte des étapes de traitement :

- **Date de réalisation des accusés de réception** : backfill des étapes existantes (ChangeLog → PDF → `updatedAt`) et enregistrement de la date à l'envoi (auto et semi-manuel).
- **Verrouillage des étapes d'accusé de réception** : une AR (manuelle comme automatique) n'est plus modifiable (statut, nom, date, suppression) ; seuls l'ajout de notes et de pièces jointes reste possible. Le PDF de l'AR reste protégé.
- **Notes vides masquées** : les anciennes notes qui ne contenaient que des fichiers (déplacés vers l'étape) ne s'affichent plus.
