### PR TITLE
fix: rajout de la catégorie parente dans l'affichage des motifs IGAS

### DIFF
--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.motifsIgas.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.motifsIgas.transformer.test.ts
@@ -18,6 +18,12 @@ vi.mock('@sirena/common/constants', () => ({
     'ACTIVITES_ESTHETIQUE_NON_REGLEMENTEES/AUTRES': 'Autres',
     'FACTURATIONS_HONORAIRES/AUTRES': 'Autres',
   },
+  motifCategoriesById: {
+    'HOTELLERIE_LOCAUX_RESTAURATION/ADMISSION': 'Hôtellerie locaux restauration',
+    'HOTELLERIE_LOCAUX_RESTAURATION/ACCUEIL': 'Hôtellerie locaux restauration',
+    'ACTIVITES_ESTHETIQUE_NON_REGLEMENTEES/AUTRES': "Activités d'esthétique non réglementées",
+    'FACTURATIONS_HONORAIRES/AUTRES': 'Facturations et honoraires',
+  },
 }));
 
 const outMotif = (idIgas: number): SirecMcIgasMotif => ({ id_igas: idIgas, igas_type: 'out' });
@@ -44,7 +50,7 @@ describe('sirecMigration.motifsIgas.transformer.ts', () => {
     const result = resolveMotifsIgas([outMotif(153), inMotif(122)]);
 
     expect(result.motifs).toEqual(['ACTIVITES_ESTHETIQUE_NON_REGLEMENTEES/AUTRES']);
-    expect(result.commentaireSuffix).toBe("Motifs IGAS d'entrée :\n- Autres");
+    expect(result.commentaireSuffix).toBe("Motifs IGAS d'entrée :\n- Facturations et honoraires / Autres");
   });
 
   it('should not set a commentaire suffix when out motifs are present but no in motifs exist', () => {
@@ -56,7 +62,9 @@ describe('sirecMigration.motifsIgas.transformer.ts', () => {
   it('should list one label per line in the commentaire suffix for multiple in motifs', () => {
     const result = resolveMotifsIgas([outMotif(153), inMotif(20)]);
 
-    expect(result.commentaireSuffix).toBe("Motifs IGAS d'entrée :\n- Admission\n- Accueil");
+    expect(result.commentaireSuffix).toBe(
+      "Motifs IGAS d'entrée :\n- Hôtellerie locaux restauration / Admission\n- Hôtellerie locaux restauration / Accueil",
+    );
   });
 
   it('should deduplicate motif ids resolved from multiple id_igas values', () => {

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.motifsIgas.transformer.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.motifsIgas.transformer.ts
@@ -1,4 +1,4 @@
-import { motifLabelsById } from '@sirena/common/constants';
+import { motifCategoriesById, motifLabelsById } from '@sirena/common/constants';
 import type { SirecMcIgasMotif } from '../../sirecMigration.repository.js';
 import { transcodeMotifIgas } from '../../transco/motifsIgas.transco.js';
 
@@ -26,7 +26,10 @@ export function resolveMotifsIgas(motifsIgas: SirecMcIgasMotif[]): MotifsIgasRes
   if (outMotifIds.length > 0) {
     const commentaireSuffix =
       inMotifIds.length > 0
-        ? [ENTREE_COMMENTAIRE_PREFIX, ...inMotifIds.map((motifId) => `- ${motifLabelsById[motifId]}`)].join('\n')
+        ? [
+            ENTREE_COMMENTAIRE_PREFIX,
+            ...inMotifIds.map((motifId) => `- ${motifCategoriesById[motifId]} / ${motifLabelsById[motifId]}`),
+          ].join('\n')
         : null;
     return { motifs: outMotifIds, commentaireSuffix };
   }

--- a/packages/common/src/constants/motifs.constant.ts
+++ b/packages/common/src/constants/motifs.constant.ts
@@ -525,4 +525,8 @@ export const motifLabelsById: Record<string, string> = Object.fromEntries(
   MOTIFS_DATA.map((motif) => [motif.id, motif.label]),
 );
 
+export const motifCategoriesById: Record<string, string> = Object.fromEntries(
+  MOTIFS_DATA.map((motif) => [motif.id, motif.category]),
+);
+
 export const motifCategories = Array.from(new Set(MOTIFS_DATA.map((m) => m.category)));


### PR DESCRIPTION
Lorsque l'on affichait les motifs IGAS dans une zone de texte, on affichait que le sous motif, on pouvait donc juste se retrouver avec "Autres". Maintenant on affiche par exemple "Qualité des soins / Autres"
