### PR TITLE
feat: migration des champs sirec public_concerne et service_concerne

### DIFF
--- a/apps/backend/src/features/sirecMigration/sirecMigration.repository.test.ts
+++ b/apps/backend/src/features/sirecMigration/sirecMigration.repository.test.ts
@@ -567,6 +567,44 @@ describe('sirecMigration.repository.ts', () => {
         { id_igas: 122, igas_type: 'in' },
       ]);
     });
+
+    it('should map service_concerne and public_concerne to serviceConcerne and publicConcerne', async () => {
+      vi.mocked(mariadbPool.query).mockResolvedValueOnce([
+        {
+          id_data: 10,
+          type: null,
+          identifiant: null,
+          id_group: null,
+          service_concerne: 68,
+          public_concerne: 71,
+          rpps_id_data: null,
+          rpps_civilite: null,
+          rpps_nom: null,
+          rpps_prenom: null,
+          rpps_code_postal: null,
+          rpps_commune: null,
+          rpps_libelle_prof: null,
+          finess_id_data: null,
+          finess_nofinesset: null,
+          finess_categetab: null,
+          finess_libcategetab: null,
+          finess_rs: null,
+          finess_codepostal: null,
+          finess_libcommune: null,
+          finess_numvoie: null,
+          finess_typevoie: null,
+          finess_voie: null,
+        },
+      ]);
+      vi.mocked(mariadbPool.query).mockResolvedValueOnce([]);
+
+      const result = await fetchSirecMisEnCauses(42);
+
+      expect(result[0].serviceConcerne).toBe(68);
+      expect(result[0].publicConcerne).toBe(71);
+      expect(mariadbPool.query).toHaveBeenCalledWith(expect.stringContaining('m.service_concerne'), [42]);
+      expect(mariadbPool.query).toHaveBeenCalledWith(expect.stringContaining('m.public_concerne'), [42]);
+    });
   });
 
   describe('fetchSirecMainCourantes', () => {

--- a/apps/backend/src/features/sirecMigration/sirecMigration.repository.ts
+++ b/apps/backend/src/features/sirecMigration/sirecMigration.repository.ts
@@ -131,6 +131,8 @@ export interface SirecMisEnCause {
   autresMcType: number | null;
   label: string | null;
   adresse: string | null;
+  serviceConcerne: number | null;
+  publicConcerne: number | null;
   groupIds: number[];
   rppsData: SirecRppsData | null;
   finessData: SirecFinessData | null;
@@ -248,6 +250,8 @@ type MisEnCauseRow = {
   autres_mc_type: number | null;
   label: string | null;
   adresse: string | null;
+  service_concerne: number | null;
+  public_concerne: number | null;
   id_group: number | null;
   rpps_id_data: number | null;
   rpps_rpps: string | null;
@@ -303,6 +307,8 @@ export async function fetchSirecMisEnCauses(sirecId: number): Promise<SirecMisEn
             m.autres_mc_type,
             m.label,
             m.adresse,
+            m.service_concerne,
+            m.public_concerne,
             mcg.id_group,
             r.id_data      AS rpps_id_data,
             r.rpps         AS rpps_rpps,
@@ -373,6 +379,8 @@ export async function fetchSirecMisEnCauses(sirecId: number): Promise<SirecMisEn
         autresMcType: row.autres_mc_type,
         label: row.label,
         adresse: row.adresse,
+        serviceConcerne: row.service_concerne,
+        publicConcerne: row.public_concerne,
         groupIds: [],
         rppsData,
         finessData,

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.test.ts
@@ -84,6 +84,7 @@ vi.mock('./sirecMigration.finess.transformer.js', () => ({
 
 vi.mock('../transco/dictionnaire.transco.js', () => ({
   SIREC_BOOLEAN_TRANSCO: { 1: true, 112: true, 0: false, 111: false },
+  SIREC_DICO: { 68: 'Addictologie', 71: 'Adultes' },
 }));
 
 vi.mock('../transco/finessCategetab.transco.js', () => ({
@@ -115,6 +116,8 @@ const makeMisEnCause = (
     autresMcType: number | null;
     label: string | null;
     adresse: string | null;
+    serviceConcerne: number | null;
+    publicConcerne: number | null;
     groupIds: number[];
     rppsData: SirecRppsData | null;
     finessData: SirecFinessData | null;
@@ -127,6 +130,8 @@ const makeMisEnCause = (
   autresMcType: null,
   label: null,
   adresse: null,
+  serviceConcerne: null,
+  publicConcerne: null,
   groupIds: [],
   rppsData: null,
   finessData: null,
@@ -428,6 +433,132 @@ describe('sirecMigration.misEnCause.transformer.ts', () => {
 
       expect(result[0].misEnCauseData).not.toBeNull();
       expect(result[1].misEnCauseData).toBeNull();
+    });
+  });
+
+  describe('service_concerne / public_concerne', () => {
+    it('should not set autrePrecision when both are null', () => {
+      const result = transformSirecMisEnCauseSituations(
+        makeData([], [makeMisEnCause({ id_data: 10, type: 65, identifiant: 12345678901, rppsData: mockRppsData })]),
+        [],
+      );
+
+      expect((result[0].misEnCauseData as any)?.autrePrecision).toBeUndefined();
+    });
+
+    it('should set autrePrecision with "Service concerné : " prefix and dictionary transco when service_concerne is set', () => {
+      const result = transformSirecMisEnCauseSituations(
+        makeData(
+          [],
+          [
+            makeMisEnCause({
+              id_data: 10,
+              type: 65,
+              identifiant: 12345678901,
+              rppsData: mockRppsData,
+              serviceConcerne: 68,
+            }),
+          ],
+        ),
+        [],
+      );
+
+      expect((result[0].misEnCauseData as any)?.autrePrecision).toBe('Service concerné : Addictologie');
+    });
+
+    it('should set autrePrecision with "Public concerné : " prefix and dictionary transco when public_concerne is set', () => {
+      const result = transformSirecMisEnCauseSituations(
+        makeData(
+          [],
+          [
+            makeMisEnCause({
+              id_data: 10,
+              type: 65,
+              identifiant: 12345678901,
+              rppsData: mockRppsData,
+              publicConcerne: 71,
+            }),
+          ],
+        ),
+        [],
+      );
+
+      expect((result[0].misEnCauseData as any)?.autrePrecision).toBe('Public concerné : Adultes');
+    });
+
+    it('should order Service concerné before Public concerné, both before Observations and Signalement', () => {
+      const result = transformSirecMisEnCauseSituations(
+        makeData(
+          [],
+          [
+            makeMisEnCause({
+              id_data: 10,
+              type: 65,
+              identifiant: 12345678901,
+              rppsData: mockRppsData,
+              serviceConcerne: 68,
+              publicConcerne: 71,
+            }),
+          ],
+          null,
+          'Texte obs',
+          1,
+        ),
+        [],
+      );
+
+      expect((result[0].misEnCauseData as any)?.autrePrecision).toBe(
+        'Service concerné : Addictologie\nPublic concerné : Adultes\nObservations : Texte obs\nEnregistré en tant que Signalement dans SIREC',
+      );
+    });
+
+    it('should throw SirecTranscoError when service_concerne has an unknown id_dico', () => {
+      expect(() =>
+        transformSirecMisEnCauseSituations(
+          makeData(
+            [],
+            [
+              makeMisEnCause({
+                id_data: 10,
+                type: 65,
+                identifiant: 12345678901,
+                rppsData: mockRppsData,
+                serviceConcerne: 999,
+              }),
+            ],
+          ),
+          [],
+        ),
+      ).toThrow(SirecTranscoError);
+    });
+
+    it('should throw SirecTranscoError when public_concerne has an unknown id_dico', () => {
+      expect(() =>
+        transformSirecMisEnCauseSituations(
+          makeData(
+            [],
+            [
+              makeMisEnCause({
+                id_data: 10,
+                type: 65,
+                identifiant: 12345678901,
+                rppsData: mockRppsData,
+                publicConcerne: 999,
+              }),
+            ],
+          ),
+          [],
+        ),
+      ).toThrow(SirecTranscoError);
+    });
+
+    it('should not set autrePrecision for null misEnCauseData even when service_concerne is set', () => {
+      const result = transformSirecMisEnCauseSituations(
+        makeData([], [makeMisEnCause({ id_data: 10, type: null, serviceConcerne: 68 })]),
+        [],
+      );
+
+      expect(result[0].misEnCauseData).toBeNull();
     });
   });
 

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.ts
@@ -1,6 +1,7 @@
+import { createDefaultLogger } from '../../../../helpers/pino.js';
 import type { SirecMisEnCause, SirecReclamationData, SirecReclamationRow } from '../../sirecMigration.repository.js';
 import { SIREC_NATIONAL_ENTITE_ID } from '../../transco/affectation/affectation.transco.js';
-import { SIREC_BOOLEAN_TRANSCO } from '../../transco/dictionnaire.transco.js';
+import { SIREC_BOOLEAN_TRANSCO, SIREC_DICO } from '../../transco/dictionnaire.transco.js';
 import { SIREC_TYPE_FINESS } from '../../transco/finessCategetab.transco.js';
 import { SIREC_TYPE_AUTRE } from '../../transco/misEnCauseAutre.transco.js';
 import { SIREC_TYPE_RPPS } from '../../transco/misEnCauseRpps.transco.js';
@@ -33,12 +34,37 @@ function appendAutrePrecision(data: SirenaMisEnCauseData | null, suffix: string 
   return { ...data, autrePrecision: data.autrePrecision ? `${data.autrePrecision}\n${suffix}` : suffix };
 }
 
+function transcodeServiceConcerne(idDico: number): string {
+  const label = SIREC_DICO[idDico];
+  if (label === undefined) throw new SirecTranscoError(idDico, 'service_concerne');
+  return label;
+}
+
+function transcodePublicConcerne(idDico: number): string {
+  const label = SIREC_DICO[idDico];
+  if (label === undefined) throw new SirecTranscoError(idDico, 'public_concerne');
+  return label;
+}
+
 function applyMisEnCauseAnnotations(
   data: SirenaMisEnCauseData | null,
   reclamation: SirecReclamationRow,
+  misEnCause?: SirecMisEnCause,
 ): SirenaMisEnCauseData | null {
-  const withObservation = appendAutrePrecision(
+  const withServiceConcerne = appendAutrePrecision(
     data,
+    misEnCause?.serviceConcerne !== null && misEnCause?.serviceConcerne !== undefined
+      ? `Service concerné : ${transcodeServiceConcerne(misEnCause.serviceConcerne)}`
+      : null,
+  );
+  const withPublicConcerne = appendAutrePrecision(
+    withServiceConcerne,
+    misEnCause?.publicConcerne !== null && misEnCause?.publicConcerne !== undefined
+      ? `Public concerné : ${transcodePublicConcerne(misEnCause.publicConcerne)}`
+      : null,
+  );
+  const withObservation = appendAutrePrecision(
+    withPublicConcerne,
     reclamation.observation ? `Observations : ${reclamation.observation}` : null,
   );
   return transcodeSignalement(reclamation.signalement) === true
@@ -117,7 +143,7 @@ export function transformSirecMisEnCauseSituations(
     return {
       ...baseSituation,
       entiteIds,
-      misEnCauseData: applyMisEnCauseAnnotations(misEnCauseData, reclamation),
+      misEnCauseData: applyMisEnCauseAnnotations(misEnCauseData, reclamation, misEnCause),
       lieuDeSurvenueData,
       fait: {
         ...baseSituation.fait,


### PR DESCRIPTION
Rajout de la migration de ces deux champs qui au départ n'était pas à migrer...
Ils ne viennent que rajouter un peu de texte dans un champ commentaire.