### PR TITLE
feat: attach logged-in user to frontend Sentry events

### DIFF
--- a/apps/frontend/src/lib/api/fetchProfile.ts
+++ b/apps/frontend/src/lib/api/fetchProfile.ts
@@ -1,6 +1,7 @@
 import type { Role, StatutType } from '@sirena/common/constants';
 import { client } from '@/lib/api/hc';
 import { handleRequestErrors } from '@/lib/api/tanstackQuery';
+import { identifySentryUser } from '@/lib/sentryUser';
 import { useUserStore } from '@/stores/userStore';
 
 export async function fetchProfile() {
@@ -10,5 +11,11 @@ export async function fetchProfile() {
   const userStore = useUserStore.getState();
   userStore.setRole(data.roleId as Role);
   userStore.setStatutId(data.statutId as StatutType);
+  identifySentryUser({
+    id: data.id,
+    email: data.email,
+    role: data.roleId,
+    topEntiteId: data.topEntiteId,
+  });
   return data;
 }

--- a/apps/frontend/src/lib/api/tanstackQuery.ts
+++ b/apps/frontend/src/lib/api/tanstackQuery.ts
@@ -3,6 +3,7 @@ import type { Cause } from '@sirena/common/types';
 import { profileQueryOptions } from '@/hooks/queries/profile.hook';
 import { queryClient } from '@/lib/queryClient';
 import { router } from '@/lib/router';
+import { clearSentryUser } from '@/lib/sentryUser';
 import { toastManager } from '@/lib/toastManager';
 import { useFeatureFlagStore } from '@/stores/featureFlagStore';
 import { useUserStore } from '@/stores/userStore';
@@ -75,6 +76,7 @@ export const handleRequestErrors = async (res: Response, options: RequestErrorOp
   if (res.status === 401) {
     const userStore = useUserStore.getState();
     userStore.logout();
+    clearSentryUser();
     useFeatureFlagStore.getState().reset();
     router.navigate({ to: '/login', search: { redirect: window.location.pathname } });
     errorFound = true;

--- a/apps/frontend/src/lib/instrument.ts
+++ b/apps/frontend/src/lib/instrument.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react';
 import { ERROR_KIND } from '@sirena/common/constants';
 import { env } from '@/config/env';
 import { APP_VERSION } from '@/config/version.constant';
+import { getLastKnownSentryUser } from '@/lib/sentryUser';
 import { getSessionId } from '@/lib/tracking';
 
 const isBusinessHttpError = (error: unknown): boolean => {
@@ -37,6 +38,22 @@ if (env.SENTRY_ENABLED === 'true') {
       const sessionId = getSessionId();
       if (!event.tags?.sessionId) {
         event.tags = { ...event.tags, sessionId, source: 'frontend' };
+      }
+
+      if (!event.user?.id) {
+        const lastUser = getLastKnownSentryUser();
+        if (lastUser) {
+          event.tags = { ...event.tags, lastKnownUserId: lastUser.id };
+          event.contexts = {
+            ...event.contexts,
+            lastKnownUser: {
+              id: lastUser.id,
+              email: lastUser.email,
+              role: lastUser.role,
+              topEntiteId: lastUser.topEntiteId,
+            },
+          };
+        }
       }
       return event;
     },

--- a/apps/frontend/src/lib/sentryUser.test.ts
+++ b/apps/frontend/src/lib/sentryUser.test.ts
@@ -1,0 +1,49 @@
+import * as Sentry from '@sentry/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearSentryUser, getLastKnownSentryUser, identifySentryUser } from './sentryUser';
+
+vi.mock('@sentry/react', () => ({
+  setUser: vi.fn(),
+  setTags: vi.fn(),
+}));
+
+const user = {
+  id: 'user-123',
+  email: 'agent@example.gouv.fr',
+  role: 'ENTITY_ADMIN',
+  topEntiteId: 'entite-42',
+};
+
+describe('sentryUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('identifySentryUser', () => {
+    it('should attach the user to the Sentry scope with role and entite tags', () => {
+      identifySentryUser(user);
+
+      expect(Sentry.setUser).toHaveBeenCalledWith({ id: 'user-123', email: 'agent@example.gouv.fr' });
+      expect(Sentry.setTags).toHaveBeenCalledWith({
+        userRole: 'ENTITY_ADMIN',
+        userTopEntiteId: 'entite-42',
+      });
+    });
+
+    it('should keep the user in memory as the last known user', () => {
+      identifySentryUser(user);
+
+      expect(getLastKnownSentryUser()).toEqual(user);
+    });
+  });
+
+  describe('clearSentryUser', () => {
+    it('should detach the user from the Sentry scope but keep the last known user', () => {
+      identifySentryUser(user);
+      clearSentryUser();
+
+      expect(Sentry.setUser).toHaveBeenCalledWith(null);
+      expect(getLastKnownSentryUser()).toEqual(user);
+    });
+  });
+});

--- a/apps/frontend/src/lib/sentryUser.ts
+++ b/apps/frontend/src/lib/sentryUser.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/react';
+
+export interface SentryUserInfo {
+  id: string;
+  email?: string;
+  role?: string | null;
+  topEntiteId?: string | null;
+}
+
+let lastKnownUser: SentryUserInfo | null = null;
+
+export const identifySentryUser = (user: SentryUserInfo) => {
+  lastKnownUser = user;
+  Sentry.setUser({ id: user.id, email: user.email });
+  Sentry.setTags({
+    userRole: user.role ?? undefined,
+    userTopEntiteId: user.topEntiteId ?? undefined,
+  });
+};
+
+export const clearSentryUser = () => {
+  Sentry.setUser(null);
+};
+
+export const getLastKnownSentryUser = (): SentryUserInfo | null => lastKnownUser;


### PR DESCRIPTION
- Sentry.setUser (id + email) and role/topEntiteId tags set when the profile is fetched
- scope user cleared on 401 logout