### PR TITLE
fix: verrouiller l'étape d'AR uniquement quand l'AR a été réellement envoyée

### DIFF
--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.test.ts
@@ -637,22 +637,34 @@ describe('RequeteEtapes.service.ts', () => {
         uploadedFiles: [],
         requete: { createdById: 'agent-1' },
       };
-      const autoAckEtape = {
+      const sentAckEtape = {
         ...requeteEtape,
         id: 'ackEtapeId',
         type: 'ACKNOWLEDGMENT',
         statutId: 'FAIT',
         notes: [],
-        uploadedFiles: [],
+        // A sent ACR carries its non-deletable AR PDF → status/name/date locked.
+        uploadedFiles: [{ id: 'ar', fileName: 'AR.pdf', metadata: null, size: 10, canDelete: false }],
         requete: { createdById: null },
       };
-      vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([closedEtape, autoAckEtape]);
-      vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(2);
+      const handMarkedAckEtape = {
+        ...requeteEtape,
+        id: 'handAckEtapeId',
+        type: 'ACKNOWLEDGMENT',
+        statutId: 'FAIT',
+        notes: [],
+        // Marked "Fait" by hand, no AR PDF → stays fully editable.
+        uploadedFiles: [],
+        requete: { createdById: 'agent-1' },
+      };
+      vi.mocked(prisma.requeteEtape.findMany).mockResolvedValueOnce([closedEtape, sentAckEtape, handMarkedAckEtape]);
+      vi.mocked(prisma.requeteEtape.count).mockResolvedValueOnce(3);
 
       const result = await getRequeteEtapes('requeteId', 'entiteId', { offset: 0 });
 
       expect(result.data[0]).toMatchObject({ editable: false, canOnlyEditNotes: false });
       expect(result.data[1]).toMatchObject({ editable: true, canOnlyEditNotes: true });
+      expect(result.data[2]).toMatchObject({ editable: true, canOnlyEditNotes: false });
     });
   });
 
@@ -870,34 +882,46 @@ describe('RequeteEtapes.service.ts', () => {
   });
 
   describe('getEtapePermissions', () => {
+    const arPdf = { canDelete: false };
+    const userFile = { canDelete: true };
+
     it('MANUAL step is fully editable', () => {
-      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'A_FAIRE' })).toEqual({
+      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'A_FAIRE', uploadedFiles: [] })).toEqual({
         editable: true,
         canOnlyEditNotes: false,
       });
     });
 
     it('CLOTUREE step is not editable', () => {
-      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'CLOTUREE' })).toEqual({
+      expect(getEtapePermissions({ type: 'MANUAL', statutId: 'CLOTUREE', uploadedFiles: [] })).toEqual({
         editable: false,
         canOnlyEditNotes: false,
       });
     });
 
     it('CREATION and REOPEN steps are not editable', () => {
-      expect(getEtapePermissions({ type: 'CREATION', statutId: 'FAIT' }).editable).toBe(false);
-      expect(getEtapePermissions({ type: 'REOPEN', statutId: 'FAIT' }).editable).toBe(false);
+      expect(getEtapePermissions({ type: 'CREATION', statutId: 'FAIT', uploadedFiles: [] }).editable).toBe(false);
+      expect(getEtapePermissions({ type: 'REOPEN', statutId: 'FAIT', uploadedFiles: [] }).editable).toBe(false);
     });
 
-    it('ACKNOWLEDGMENT step is always notes-only (automatic and manual behave identically)', () => {
-      // Regardless of statut or who created the request, an ACR is a notes/attachments container:
-      // status, name and date stay locked.
-      for (const statutId of ['FAIT', 'A_FAIRE']) {
-        expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId })).toEqual({
-          editable: true,
-          canOnlyEditNotes: true,
-        });
-      }
+    it('ACKNOWLEDGMENT is notes-only once the AR was sent (AR PDF attached)', () => {
+      expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', uploadedFiles: [arPdf] })).toEqual({
+        editable: true,
+        canOnlyEditNotes: true,
+      });
+    });
+
+    it('ACKNOWLEDGMENT stays fully editable when marked "Fait" by hand (no AR PDF)', () => {
+      // No send, no non-deletable AR PDF → status/name/date remain editable.
+      expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'FAIT', uploadedFiles: [] })).toEqual({
+        editable: true,
+        canOnlyEditNotes: false,
+      });
+      // A user-added attachment (canDelete: true) is not an AR PDF, so it does not lock the step.
+      expect(getEtapePermissions({ type: 'ACKNOWLEDGMENT', statutId: 'A_FAIRE', uploadedFiles: [userFile] })).toEqual({
+        editable: true,
+        canOnlyEditNotes: false,
+      });
     });
   });
 

--- a/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
+++ b/apps/backend/src/features/requeteEtapes/requetesEtapes.service.ts
@@ -152,16 +152,18 @@ export const createDefaultRequeteEtapes = async (
 export const getEtapePermissions = (etape: {
   type: string;
   statutId: string | null;
+  uploadedFiles: { canDelete: boolean }[];
 }): { editable: boolean; canOnlyEditNotes: boolean } => {
   if (etape.statutId === REQUETE_ETAPE_STATUT_TYPES.CLOTUREE) return { editable: false, canOnlyEditNotes: false };
   if (etape.type === REQUETE_ETAPE_TYPES.CREATION || etape.type === REQUETE_ETAPE_TYPES.REOPEN) {
     return { editable: false, canOnlyEditNotes: false };
   }
-  // An acknowledgment step is always a notes/attachments container: status, name and date stay
-  // locked, only notes can be edited. Manual ACRs behave exactly like automatic ones (the AR send,
-  // auto or semi-manual from SIRENA, is authoritative), so this no longer depends on who created the request.
-  const canOnlyEditNotes = etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT;
-  return { editable: true, canOnlyEditNotes };
+  // An acknowledgment step is locked (notes/attachments only) only once the AR was actually sent from
+  // SIRENA — i.e. its non-deletable AR PDF (canDelete === false) is attached, by the auto or semi-manual
+  // send. If the step was merely switched to "Fait" by hand (no send, no PDF), it stays fully editable.
+  const acknowledgmentSent =
+    etape.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT && etape.uploadedFiles.some((file) => !file.canDelete);
+  return { editable: true, canOnlyEditNotes: acknowledgmentSent };
 };
 
 export class EtapeNotEditableError extends Error {
@@ -560,11 +562,12 @@ export const getRequeteEtapes = async (requeteId: string, entiteId: string | nul
     return { ...rest, fileName: getOriginalFileName(file) };
   };
 
-  // closure / creation = not editable; automatic ACR = statut + files locked but notes OK; manual = full.
+  // closure / creation = not editable; a sent ACR (AR PDF attached) = statut/name/date locked, notes OK; else full.
   const data = raw.map((etape) => {
     const { editable, canOnlyEditNotes } = getEtapePermissions({
       type: etape.type,
       statutId: etape.statutId,
+      uploadedFiles: etape.uploadedFiles,
     });
     return {
       ...etape,

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
@@ -260,4 +260,27 @@ describe('StepFormPanel', () => {
     expect(screen.getByText('Sélectionner un fichier')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ajouter une note' })).toBeInTheDocument();
   });
+
+  it('locks name and hides delete but keeps status editable for a not-yet-sent ACR step', () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() =>
+      ref.current?.openEdit(
+        makeStep({
+          type: REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT,
+          statutId: REQUETE_ETAPE_STATUT_TYPES.FAIT,
+          dateRealisation: '2026-05-20T00:00:00.000Z',
+          canOnlyEditNotes: false, // AR marked "Fait" by hand — no AR PDF, not sent
+        }),
+      ),
+    );
+
+    // Name and deletion stay locked (acknowledgment = system step)...
+    expect(screen.getByLabelText("Nom de l'étape (obligatoire)")).toBeDisabled();
+    expect(screen.queryByRole('button', { name: "Supprimer l'étape" })).not.toBeInTheDocument();
+    // ...but status and date remain editable since the AR has not been sent.
+    expect(screen.getByLabelText('Fait')).toBeEnabled();
+    expect(screen.getByLabelText('À faire')).toBeEnabled();
+  });
 });

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -2,7 +2,7 @@ import { Button } from '@codegouvfr/react-dsfr/Button';
 import { Input } from '@codegouvfr/react-dsfr/Input';
 import { createModal } from '@codegouvfr/react-dsfr/Modal';
 import { RadioButtons } from '@codegouvfr/react-dsfr/RadioButtons';
-import { REQUETE_ETAPE_STATUT_TYPES } from '@sirena/common/constants';
+import { REQUETE_ETAPE_STATUT_TYPES, REQUETE_ETAPE_TYPES } from '@sirena/common/constants';
 import { Drawer, Toast } from '@sirena/ui';
 import { forwardRef, useEffect, useId, useImperativeHandle, useRef, useState } from 'react';
 import { FileDownloadLink } from '@/components/common/FileDownloadLink';
@@ -104,6 +104,9 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const [editStepId, setEditStepId] = useState<string | null>(null);
   const [editStepNom, setEditStepNom] = useState('');
   const [canOnlyEditNotes, setCanOnlyEditNotes] = useState(false);
+  // An acknowledgment step is a system step: its name and deletion stay locked even before the AR is sent
+  // (like pre-release prod). Only its status/date become editable while the AR has not been sent.
+  const [isAcknowledgment, setIsAcknowledgment] = useState(false);
 
   const [nom, setNom] = useState('');
   const [nomError, setNomError] = useState<string | null>(null);
@@ -146,6 +149,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
     setMode('create');
     setEditStepId(null);
     setCanOnlyEditNotes(false);
+    setIsAcknowledgment(false);
     setNotes([{ key: nextNoteKey(), texte: '' }]);
     setIsOpen(true);
   };
@@ -157,6 +161,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
     setEditStepId(step.id);
     setEditStepNom(step.nom);
     setCanOnlyEditNotes(step.canOnlyEditNotes);
+    setIsAcknowledgment(step.type === REQUETE_ETAPE_TYPES.ACKNOWLEDGMENT);
     setNom(step.nom);
 
     const initialStatut =
@@ -406,7 +411,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                   >
                     <Input
                       label="Nom de l'étape (obligatoire)"
-                      disabled={isLoading || fieldsLocked}
+                      disabled={isLoading || fieldsLocked || isAcknowledgment}
                       state={nomError ? 'error' : 'default'}
                       stateRelatedMessage={nomError ?? undefined}
                       nativeInputProps={{
@@ -600,7 +605,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                     </section>
 
                     <div className={styles.footerActions}>
-                      {mode === 'edit' && !fieldsLocked && (
+                      {mode === 'edit' && !fieldsLocked && !isAcknowledgment && (
                         <Button
                           type="button"
                           priority="secondary"


### PR DESCRIPTION
Suite d'un retour sur la refonte des étapes (la PR précédente est mergée). Aligne l'étape d'accusé de réception sur le comportement d'avant la release (v1.12.0) :

- Le **nom** et la **suppression** de l'étape restent verrouillés en permanence (étape « système »).
- Le **statut** et la **date** ne sont verrouillés que si l'AR a réellement été envoyée depuis SIRENA (présence du PDF d'AR `canDelete=false`). Si l'étape a simplement été passée à « Fait » à la main, statut et date redeviennent modifiables.
- Notes et pièces jointes restent ajoutables dans tous les cas.

Le signal « envoyé » de prod (note système « Email d'accusé de réception envoyé le… ») a été supprimé par la release ; il est remplacé par le PDF d'AR attaché à l'étape.