### PR TITLE
fix: titre « Notes » dans le panneau de modification d'étape

### DIFF
--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
@@ -160,6 +160,16 @@ describe('StepFormPanel', () => {
     expect(screen.getByText(/Note du 02-01-2026 \(lecture seule\)/)).toBeInTheDocument();
   });
 
+  it('shows a "Notes" heading in edit mode, even with no notes, so the add-note button is not tied to the status section', () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() => ref.current?.openEdit(makeStep({ notes: [] })));
+
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ajouter une note' })).toBeInTheDocument();
+  });
+
   it('removes an editable note via its delete button', async () => {
     const ref = createRef<StepFormPanelRef>();
     render(<StepFormPanel ref={ref} requestId="REQ-1" />);

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.test.tsx
@@ -170,6 +170,24 @@ describe('StepFormPanel', () => {
     expect(screen.getByRole('button', { name: 'Ajouter une note' })).toBeInTheDocument();
   });
 
+  it('moves focus into the new note textarea when adding a note', async () => {
+    const ref = createRef<StepFormPanelRef>();
+    render(<StepFormPanel ref={ref} requestId="REQ-1" />);
+
+    act(() => ref.current?.openEdit(makeStep({ notes: [] })));
+    // Let the panel's open-focus (heading) settle first, as it does in the real app.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Ajouter une note' }));
+    });
+
+    // Focus lands in the note textarea, not on the add-note button.
+    expect(document.activeElement?.tagName).toBe('TEXTAREA');
+  });
+
   it('removes an editable note via its delete button', async () => {
     const ref = createRef<StepFormPanelRef>();
     render(<StepFormPanel ref={ref} requestId="REQ-1" />);

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -476,6 +476,7 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                     )}
 
                     <section className={styles.notesSection}>
+                      {mode === 'edit' && <p className={`fr-label ${styles.attachmentTitle}`}>Notes</p>}
                       {readOnlyNotes.map((note) => (
                         <div key={note.id} className={styles.readOnlyNote}>
                           <p className={styles.readOnlyNoteLabel}>

--- a/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
+++ b/apps/frontend/src/components/requestId/processing/StepFormPanel.tsx
@@ -98,6 +98,8 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const headingRef = useRef<HTMLHeadingElement>(null);
   const nomInputRef = useRef<HTMLInputElement>(null);
   const dateInputRef = useRef<HTMLInputElement>(null);
+  // Key of a freshly added note whose textarea should receive focus once it mounts.
+  const pendingFocusNoteKey = useRef<string | null>(null);
 
   const [isOpen, setIsOpen] = useState(false);
   const [mode, setMode] = useState<'create' | 'edit'>('create');
@@ -230,7 +232,9 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
   const fieldsLocked = canOnlyEditNotes;
 
   const handleAddNote = () => {
-    setNotes((prev) => [...prev, { key: nextNoteKey(), texte: '' }]);
+    const key = nextNoteKey();
+    pendingFocusNoteKey.current = key;
+    setNotes((prev) => [...prev, { key, texte: '' }]);
   };
 
   const handleRemoveNote = (key: string) => {
@@ -523,6 +527,13 @@ export const StepFormPanel = forwardRef<StepFormPanelRef, StepFormPanelProps>(({
                                 note.texte.length > NOTE_MAX_LENGTH ? NOTE_MAX_LENGTH_ERROR : undefined
                               }
                               nativeTextAreaProps={{
+                                // Move focus into a freshly added note's textarea as soon as it mounts.
+                                ref: (el: HTMLTextAreaElement | null) => {
+                                  if (el && pendingFocusNoteKey.current === note.key) {
+                                    el.focus();
+                                    pendingFocusNoteKey.current = null;
+                                  }
+                                },
                                 rows: 6,
                                 value: note.texte,
                                 onChange: (e) => handleNoteChange(note.key, e.target.value),


### PR DESCRIPTION
Deux petits retours UX sur le panneau « Modifier l'étape » (section notes) :

- **Titre « Notes »** au-dessus de la liste des notes. Sans lui, quand toutes les notes étaient supprimées, le bouton « Ajouter une note » semblait rattaché à la rubrique « Statut de l'étape ». Le titre le regroupe clairement (comme « Fichiers ajoutés »).
- **Focus dans la nouvelle note** : en cliquant « Ajouter une note », le focus va désormais dans le textarea de la note, au lieu de rester sur le bouton.