### PR TITLE
fix: guard optional situations chain in RequestForm motifs (PSN-SIRENA-FRONTEND-M2-36)

### DIFF
--- a/apps/frontend/src/components/requestForm/RequestForm.tsx
+++ b/apps/frontend/src/components/requestForm/RequestForm.tsx
@@ -57,9 +57,9 @@ export function RequestForm({ requestId, activeTab: activeTabProp = 0 }: Request
 
   const motifs = [
     ...new Set(
-      requestQuery.data?.requete.situations.flatMap((s) =>
-        s.faits.flatMap((f) => f.motifs.flatMap((m) => (m.motif.label ? [m.motif.label] : []))),
-      ) || [],
+      requestQuery.data?.requete.situations?.flatMap((s) =>
+        s.faits?.flatMap((f) => f.motifs?.flatMap((m) => (m.motif.label ? [m.motif.label] : [])) ?? []) ?? [],
+      ) ?? [],
     ),
   ];
   const statutId = requestQuery.data?.statutId || '';


### PR DESCRIPTION
The motifs computation dereferenced situations/faits/motifs with only data? guarding the root, unlike the sibling allFiles computation just below which guards situations?. A response without situations (SSE refetch, partial payload) threw 'Cannot read properties of undefined (reading map)' and broke the request detail page via the ErrorBoundary.

Fixes PSN-SIRENA-FRONTEND-M2-36