### PR TITLE
feat: add timeout handling to file integrity check job

### DIFF
--- a/apps/backend/src/features/uploadedFiles/fileIntegrity.service.ts
+++ b/apps/backend/src/features/uploadedFiles/fileIntegrity.service.ts
@@ -1,4 +1,4 @@
-import { getLoggerStore } from '../../libs/asyncLocalStorage.js';
+import { abortControllerStorage, getLoggerStore } from '../../libs/asyncLocalStorage.js';
 import { deleteFileFromMinio, listMinioObjects } from '../../libs/minio.js';
 import { prisma } from '../../libs/prisma.js';
 
@@ -24,10 +24,18 @@ export async function runFileIntegrityCheck(options?: {
   removeDangling?: boolean;
 }): Promise<FileIntegrityResult> {
   const logger = getLoggerStore();
+  const signal = abortControllerStorage.getStore()?.signal;
   const { removeOrphans = false, removeDangling = false } = options ?? {};
+
+  const throwIfAborted = (phase: string): void => {
+    if (signal?.aborted) {
+      throw new Error(`File integrity check aborted (timeout) during phase: ${phase}`);
+    }
+  };
 
   logger.info({ removeOrphans, removeDangling }, 'Starting file integrity check');
 
+  throwIfAborted('db-fetch');
   const dbStartedAt = Date.now();
   const dbFiles = await prisma.uploadedFile.findMany({
     select: {
@@ -47,6 +55,7 @@ export async function runFileIntegrityCheck(options?: {
   logger.info({ count: dbFiles.length, durationMs: Date.now() - dbStartedAt }, 'Fetched uploaded files from database');
   logger.info(`Found ${dbFiles.length} files in database`);
 
+  throwIfAborted('s3-list');
   const s3StartedAt = Date.now();
   const s3Objects = await listMinioObjects();
   const s3Paths = new Set(s3Objects.map((o) => o.name));
@@ -89,6 +98,8 @@ export async function runFileIntegrityCheck(options?: {
   for (const [i, f] of s3FilesWithoutDb.entries()) {
     logger.warn(`orphan-s3 | ${i + 1} | ${f.name} | ${formatBytes(f.size)} | ${f.lastModified.toISOString()}`);
   }
+
+  throwIfAborted('removal');
 
   if (removeOrphans && (orphanDbFiles.length > 0 || s3FilesWithoutDb.length > 0)) {
     logger.info(

--- a/apps/backend/src/jobs/config/job.definitions.ts
+++ b/apps/backend/src/jobs/config/job.definitions.ts
@@ -45,7 +45,9 @@ export const jobHandlers = [
     name: 'file-integrity-check',
     task: fileIntegrityCheck,
     repeatEveryMs: parseInt(envVars.CRON_FILE_INTEGRITY_CHECK, 10) * 1000,
-    data: {},
+    data: {
+      timeoutMs: 1000 * 60 * 10,
+    },
     runOnStart: false,
   },
   {

--- a/apps/backend/src/jobs/config/job.types.ts
+++ b/apps/backend/src/jobs/config/job.types.ts
@@ -11,7 +11,9 @@ export type JobDataMap = {
     batchSize: number;
   };
   'queue-unprocessed-files': Record<string, never>;
-  'file-integrity-check': Record<string, never>;
+  'file-integrity-check': {
+    timeoutMs: number;
+  };
   'purge-access-logs': {
     retentionDays: number;
   };

--- a/apps/backend/src/jobs/tasks/fileIntegrityCheck.task.ts
+++ b/apps/backend/src/jobs/tasks/fileIntegrityCheck.task.ts
@@ -1,13 +1,29 @@
 import type { Job } from 'bullmq';
 import { recordFileIntegrity } from '../../features/monitoring/metrics.worker.js';
 import { runFileIntegrityCheck } from '../../features/uploadedFiles/fileIntegrity.service.js';
+import { abortControllerStorage, getLoggerStore } from '../../libs/asyncLocalStorage.js';
 import type { JobDataMap, JobResult } from '../config/job.types.js';
 import { withCronLifecycle } from '../config/job.utils.js';
 
 export async function fileIntegrityCheck(job: Job<JobDataMap['file-integrity-check']>): JobResult {
-  await withCronLifecycle(job, {}, async () => {
-    const result = await runFileIntegrityCheck();
-    recordFileIntegrity(result);
-    return result;
+  const logger = getLoggerStore();
+
+  await withCronLifecycle(job, { timeoutMs: job.data.timeoutMs }, async (j) => {
+    const controller = new AbortController();
+
+    const timeout = setTimeout(() => {
+      logger.warn(`Job ${job.name} aborted after ${j.data.timeoutMs}ms`);
+      controller.abort();
+    }, j.data.timeoutMs);
+
+    try {
+      return await abortControllerStorage.run(controller, async () => {
+        const result = await runFileIntegrityCheck();
+        recordFileIntegrity(result);
+        return result;
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
   });
 }

--- a/apps/backend/src/jobs/worker/cron.worker.ts
+++ b/apps/backend/src/jobs/worker/cron.worker.ts
@@ -45,3 +45,36 @@ export const cronWorker = new Worker(
   },
   { connection, concurrency: 5 },
 );
+
+const eventLogger = createDefaultLogger().child({ context: 'cron-worker' });
+
+cronWorker.on('completed', (job) => {
+  eventLogger.info({ jobName: job.name, jobId: job.id, attemptsMade: job.attemptsMade }, 'Cron worker job completed');
+});
+
+// Catches BullMQ-level failures that never reach withCronLifecycle's try/catch
+// (stalled jobs, lock-renewal loss, OOM-killed or restarted process mid-run).
+// Without this, a stalled cron job produces no logs at all.
+cronWorker.on('failed', (job, err) => {
+  eventLogger.error(
+    {
+      jobName: job?.name,
+      jobId: job?.id,
+      attemptsMade: job?.attemptsMade,
+      failedReason: job?.failedReason,
+      err,
+    },
+    'Cron worker job failed',
+  );
+});
+
+cronWorker.on('stalled', (jobId) => {
+  eventLogger.warn(
+    { jobId },
+    'Cron worker job stalled (lock not renewed — likely blocked event loop or process restart)',
+  );
+});
+
+cronWorker.on('error', (err) => {
+  eventLogger.error({ err }, 'Cron worker error');
+});


### PR DESCRIPTION
Add timeout configuration to file-integrity-check job definition Check for job abort signals during file integrity check phases Add BullMQ event handlers for better cron job monitoring