### PR TITLE
Fix/migration correction 1

### DIFF
--- a/apps/backend/src/features/sirecMigration/transformers/sirecMigration.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/sirecMigration.transformer.test.ts
@@ -143,8 +143,8 @@ describe('sirecMigration.transformer.ts', () => {
       situations: [
         {
           fait: {
-            commentaire: 'Précision prioritaire',
-            autresPrecisions: 'Ma réclamation',
+            autresPrecisions:
+              'Précision sur le caractère prioritaire : Précision prioritaire\nDescription de la Pré-identification : Ma réclamation',
             motifsDeclaratifs: ['PROBLEME_FACTURATION'],
             motifs: [],
           },

--- a/apps/backend/src/features/sirecMigration/transformers/sirecMigration.transformer.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/sirecMigration.transformer.ts
@@ -1,5 +1,5 @@
 import { REQUETE_PRIORITE_TYPES } from '@sirena/common/constants';
-import { generateSirenaIdFromSirecReclamation } from '../../../helpers/sirecMigration.js';
+import { generateSirenaIdFromSirecReclamation, toSirecLocalDate } from '../../../helpers/sirecMigration.js';
 import type { SirecReclamationData } from '../sirecMigration.repository.js';
 import { filterArsEntiteIds } from '../transco/affectation/affectation.transco.js';
 import { transcodeReceptionType } from '../transco/receptionType.transco.js';
@@ -52,13 +52,15 @@ export function transformSirecReclamation(sirecData: SirecReclamationData): Sire
   return {
     sirenaId: generateSirenaIdFromSirecReclamation(sirecData.reclamation),
     sirecId: sirecData.reclamation.id_data,
-    receptionDate: sirecData.reclamation.r_recept_date,
+    receptionDate: sirecData.reclamation.r_recept_date ? toSirecLocalDate(sirecData.reclamation.r_recept_date) : null,
     receptionTypeId: transcodeReceptionType(sirecData.reclamation.reception),
     prioriteId: sirecData.reclamation.prioritaire === 1 ? REQUETE_PRIORITE_TYPES.HAUTE : null,
     requeteStatutId,
     sysLastModDate: sirecData.reclamation.sys_last_mod_date,
     sysCreationDate: sirecData.reclamation.sys_creation_date,
-    dateDemandeDeclarant: sirecData.reclamation.date_ecriture,
+    dateDemandeDeclarant: sirecData.reclamation.date_ecriture
+      ? toSirecLocalDate(sirecData.reclamation.date_ecriture)
+      : null,
     declarant,
     victime,
     requeteEntiteIds,

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.test.ts
@@ -19,7 +19,7 @@ describe('sirecMigration.fait.transformer.ts', () => {
     reclamation: {
       id_data: 42,
       r_recept_date: new Date('2024-01-15'),
-      description: 'Ma réclamation',
+      description: null,
       prioritaire_precisez: 'Précision prioritaire',
       dest: null as number | null,
       dest_primaire: null as string | null,
@@ -38,28 +38,30 @@ describe('sirecMigration.fait.transformer.ts', () => {
     misEnCauses: [],
   } as unknown as SirecReclamationData;
 
-  it('should map prioritaire_precisez to commentaire when dest is null', () => {
+  it('should map prioritaire_precisez to autresPrecisions when dest is null', () => {
     const result = transformSirecFait(sirecData);
 
-    expect(result.commentaire).toBe('Précision prioritaire');
+    expect(result.autresPrecisions).toBe('Précision sur le caractère prioritaire : Précision prioritaire');
   });
 
-  it('should default commentaire to empty string when both prioritaire_precisez and dest are null', () => {
+  it('should default autresPrecisions to empty string when both prioritaire_precisez and dest are null', () => {
     const result = transformSirecFait({
       ...sirecData,
       reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, dest: null },
     });
 
-    expect(result.commentaire).toBe('');
+    expect(result.autresPrecisions).toBe('');
   });
 
-  it('should append dest label to commentaire when dest is set', () => {
+  it('should append dest label to autresPrecisions when dest is set', () => {
     const result = transformSirecFait({
       ...sirecData,
       reclamation: { ...sirecData.reclamation, dest: 12 },
     });
 
-    expect(result.commentaire).toBe('Précision prioritaire\nDestinataire(s) de la réclamation : Courriel');
+    expect(result.autresPrecisions).toBe(
+      'Précision sur le caractère prioritaire : Précision prioritaire\nDestinataire(s) de la réclamation : Courriel',
+    );
   });
 
   it('should use only dest label when prioritaire_precisez is null', () => {
@@ -68,7 +70,7 @@ describe('sirecMigration.fait.transformer.ts', () => {
       reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, dest: 12 },
     });
 
-    expect(result.commentaire).toBe('Destinataire(s) de la réclamation : Courriel');
+    expect(result.autresPrecisions).toBe('Destinataire(s) de la réclamation : Courriel');
   });
 
   it('should delegate dest transcoding to transcodeDest', async () => {
@@ -80,13 +82,19 @@ describe('sirecMigration.fait.transformer.ts', () => {
   });
 
   it('should map description to autresPrecisions', () => {
-    const result = transformSirecFait(sirecData);
+    const result = transformSirecFait({
+      ...sirecData,
+      reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, description: 'Ma réclamation' },
+    });
 
     expect(result.autresPrecisions).toBe('Description de la Pré-identification : Ma réclamation');
   });
 
   it('should default autresPrecisions to empty string when description is null', () => {
-    const result = transformSirecFait({ ...sirecData, reclamation: { ...sirecData.reclamation, description: null } });
+    const result = transformSirecFait({
+      ...sirecData,
+      reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, description: null },
+    });
 
     expect(result.autresPrecisions).toBe('');
   });
@@ -99,22 +107,26 @@ describe('sirecMigration.fait.transformer.ts', () => {
     expect(transcodeMotifsDeclaratifs).toHaveBeenCalledWith([809, 811]);
   });
 
-  it('should append dest_primaire label to commentaire when set', () => {
+  it('should append dest_primaire label to autresPrecisions when set', () => {
     const result = transformSirecFait({
       ...sirecData,
       reclamation: { ...sirecData.reclamation, dest_primaire: 'Service X' },
     });
 
-    expect(result.commentaire).toBe('Précision prioritaire\nDestinataire primaire : Service X');
+    expect(result.autresPrecisions).toBe(
+      'Précision sur le caractère prioritaire : Précision prioritaire\nDestinataire primaire : Service X',
+    );
   });
 
-  it('should append dest_secondaire label to commentaire when set', () => {
+  it('should append dest_secondaire label to autresPrecisions when set', () => {
     const result = transformSirecFait({
       ...sirecData,
       reclamation: { ...sirecData.reclamation, dest_secondaire: 'Service Y' },
     });
 
-    expect(result.commentaire).toBe('Précision prioritaire\nDestinataire secondaire : Service Y');
+    expect(result.autresPrecisions).toBe(
+      'Précision sur le caractère prioritaire : Précision prioritaire\nDestinataire secondaire : Service Y',
+    );
   });
 
   it('should append both dest_primaire and dest_secondaire when both are set', () => {
@@ -123,8 +135,8 @@ describe('sirecMigration.fait.transformer.ts', () => {
       reclamation: { ...sirecData.reclamation, dest_primaire: 'Service X', dest_secondaire: 'Service Y' },
     });
 
-    expect(result.commentaire).toBe(
-      'Précision prioritaire\nDestinataire primaire : Service X\nDestinataire secondaire : Service Y',
+    expect(result.autresPrecisions).toBe(
+      'Précision sur le caractère prioritaire : Précision prioritaire\nDestinataire primaire : Service X\nDestinataire secondaire : Service Y',
     );
   });
 
@@ -134,7 +146,7 @@ describe('sirecMigration.fait.transformer.ts', () => {
       reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, dest_primaire: null, dest_secondaire: null },
     });
 
-    expect(result.commentaire).toBe('');
+    expect(result.autresPrecisions).toBe('');
   });
 
   it('should not include dest_primaire when it is an empty string', () => {
@@ -143,16 +155,16 @@ describe('sirecMigration.fait.transformer.ts', () => {
       reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, dest_primaire: '' },
     });
 
-    expect(result.commentaire).toBe('');
+    expect(result.autresPrecisions).toBe('');
   });
 
-  it('should append courrier_signal label to commentaire when set', () => {
+  it('should append courrier_signal label to autresPrecisions when set', () => {
     const result = transformSirecFait({
       ...sirecData,
       reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, courrier_signal: 10 },
     });
 
-    expect(result.commentaire).toBe('Courrier signalé : Courrier');
+    expect(result.autresPrecisions).toBe('Courrier signalé : Courrier');
   });
 
   it('should not include courrier_signal line when courrier_signal is null', () => {
@@ -161,7 +173,7 @@ describe('sirecMigration.fait.transformer.ts', () => {
       reclamation: { ...sirecData.reclamation, prioritaire_precisez: null, courrier_signal: null },
     });
 
-    expect(result.commentaire).toBe('');
+    expect(result.autresPrecisions).toBe('');
   });
 
   it('should delegate courrier_signal transcoding to transcodeCourrierSignal', async () => {

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.test.ts
@@ -82,7 +82,7 @@ describe('sirecMigration.fait.transformer.ts', () => {
   it('should map description to autresPrecisions', () => {
     const result = transformSirecFait(sirecData);
 
-    expect(result.autresPrecisions).toBe('Ma réclamation');
+    expect(result.autresPrecisions).toBe('Description de la Pré-identification : Ma réclamation');
   });
 
   it('should default autresPrecisions to empty string when description is null', () => {

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.ts
@@ -4,8 +4,8 @@ import { transcodeDest } from '../../transco/dest.transco.js';
 import { transcodeMotifsDeclaratifs } from '../../transco/motifsDeclaratifs.transco.js';
 
 export interface SirenaFaitData {
-  commentaire: string;
-  autresPrecisions: string;
+  commentaire?: string;
+  autresPrecisions?: string;
   motifsDeclaratifs: string[];
   motifs: string[];
 }
@@ -13,8 +13,13 @@ export interface SirenaFaitData {
 export function transformSirecFait(sirecData: SirecReclamationData): SirenaFaitData {
   const destLabel = transcodeDest(sirecData.reclamation.dest);
   const courrierSignalLabel = transcodeCourrierSignal(sirecData.reclamation.courrier_signal);
-  const commentaireParts = [
-    sirecData.reclamation.prioritaire_precisez,
+  const autresPrecisionsParts = [
+    sirecData.reclamation.prioritaire_precisez
+      ? `Précision sur le caractère prioritaire : ${sirecData.reclamation.prioritaire_precisez}`
+      : null,
+    sirecData.reclamation.description
+      ? `Description de la Pré-identification : ${sirecData.reclamation.description}`
+      : null,
     destLabel ? `Destinataire(s) de la réclamation : ${destLabel}` : null,
     sirecData.reclamation.dest_primaire ? `Destinataire primaire : ${sirecData.reclamation.dest_primaire}` : null,
     sirecData.reclamation.dest_secondaire ? `Destinataire secondaire : ${sirecData.reclamation.dest_secondaire}` : null,
@@ -22,10 +27,7 @@ export function transformSirecFait(sirecData: SirecReclamationData): SirenaFaitD
   ].filter(Boolean) as string[];
 
   return {
-    commentaire: commentaireParts.join('\n'),
-    autresPrecisions: sirecData.reclamation.description
-      ? `Description de la Pré-identification : ${sirecData.reclamation.description}`
-      : '',
+    autresPrecisions: autresPrecisionsParts.join('\n'),
     motifsDeclaratifs: [...new Set(transcodeMotifsDeclaratifs(sirecData.motifsDeclaresIdDicos))],
     motifs: [],
   };

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.fait.transformer.ts
@@ -23,7 +23,9 @@ export function transformSirecFait(sirecData: SirecReclamationData): SirenaFaitD
 
   return {
     commentaire: commentaireParts.join('\n'),
-    autresPrecisions: sirecData.reclamation.description ?? '',
+    autresPrecisions: sirecData.reclamation.description
+      ? `Description de la Pré-identification : ${sirecData.reclamation.description}`
+      : '',
     motifsDeclaratifs: [...new Set(transcodeMotifsDeclaratifs(sirecData.motifsDeclaresIdDicos))],
     motifs: [],
   };

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.test.ts
@@ -24,7 +24,7 @@ vi.mock('./sirecMigration.affectation.transformer.js', () => ({
 
 vi.mock('./sirecMigration.situation.transformer.js', () => ({
   transformSirecSituation: vi.fn((_sirecData: unknown, entiteIds: string[]) => ({
-    fait: { commentaire: 'Commentaire', autresPrecisions: 'Description', motifsDeclaratifs: ['MOTIF_A'], motifs: [] },
+    fait: { autresPrecisions: 'Description', motifsDeclaratifs: ['MOTIF_A'], motifs: [] },
     entiteIds,
     demarchesIds: [],
     misEnCauseData: null,
@@ -740,26 +740,6 @@ describe('sirecMigration.misEnCause.transformer.ts', () => {
       );
 
       expect(result[0].fait.motifs).toEqual(['MOTIF_OUT_153']);
-    });
-
-    it('should append the entry motifs commentaire suffix to the base commentaire', () => {
-      const result = transformSirecMisEnCauseSituations(
-        makeData(
-          [],
-          [
-            makeMisEnCause({
-              id_data: 10,
-              motifsIgas: [
-                { id_igas: 153, igas_type: 'out' },
-                { id_igas: 122, igas_type: 'in' },
-              ],
-            }),
-          ],
-        ),
-        [],
-      );
-
-      expect(result[0].fait.commentaire).toBe("Commentaire\nMotifs IGAS d'entrée :\n- MOTIF_IN_122");
     });
 
     it('should resolve motifs independently for each mis en cause', () => {

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.misEnCause.transformer.ts
@@ -170,9 +170,7 @@ export function transformSirecMisEnCauseSituations(
       fait: {
         ...baseSituation.fait,
         motifs,
-        commentaire: commentaireSuffix
-          ? [baseSituation.fait.commentaire, commentaireSuffix].filter(Boolean).join('\n')
-          : baseSituation.fait.commentaire,
+        commentaire: commentaireSuffix ? commentaireSuffix : undefined,
       },
     };
   });

--- a/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.situation.transformer.test.ts
+++ b/apps/backend/src/features/sirecMigration/transformers/situation/sirecMigration.situation.transformer.test.ts
@@ -30,7 +30,7 @@ describe('sirecMigration.situation.transformer.ts', () => {
   it('should map description to fait.autresPrecisions', () => {
     const result = transformSirecSituation(sirecData, []);
 
-    expect(result.fait.autresPrecisions).toBe('Ma réclamation');
+    expect(result.fait.autresPrecisions).toBe('Description de la Pré-identification : Ma réclamation');
   });
 
   it('should transcode motifsDeclaresIdDicos into fait.motifsDeclaratifs', () => {


### PR DESCRIPTION
3 petits correctifs dans cette PR : 
- Suppression de l'heure des dates de réception et de demande du requérant pour se caler sur l'heure de SIREC.
- Rajout d'un préfixe pour le texte de description de la Pré-identification d'une réclamation SIREC.
- Déplacer des champs texte SIREC dans la bonne textarea de SIRENA (Fait.commentaire => Fait.autresPrecision)